### PR TITLE
fix: agent_identity_prompt 去重逻辑丢失同名 label 的 metadata 值 (10行修复)

### DIFF
--- a/backend/app/core/agent_loop.py
+++ b/backend/app/core/agent_loop.py
@@ -119,21 +119,22 @@ def _agent_identity_prompt(agent: AgentProfile) -> str:
     description = _single_line_text(agent.description)
     if description:
         lines.append(f"员工描述：{description}")
-    seen_labels: set[str] = set()
-    for key, label in AGENT_PERSONA_METADATA_FIELDS:
-        value = _metadata_prompt_text(metadata.get(key))
-        if not value:
-            continue
-        if label in seen_labels and label in {"岗位"}:
-            continue
-        seen_labels.add(label)
-        lines.append(f"{label}：{value}")
+   
     persona = str(agent.persona_prompt or "").strip()
     if persona:
         lines.append("")
         lines.append("员工角色补充要求：")
         lines.append(persona)
-
+ label_values: dict[str, list[str]] = {}
+    for key, label in AGENT_PERSONA_METADATA_FIELDS:
+        value = _metadata_prompt_text(metadata.get(key))
+        if not value:
+            continue
+        if label not in label_values:
+            label_values[label] = []
+        label_values[label].append(value)
+    for label, values in label_values.items():
+        lines.append(f"{label}：{'; '.join(values)}")
     rendered_values = []
     for key2, label2 in AGENT_PERSONA_METADATA_FIELDS:
         if label2 != label:

--- a/backend/app/core/agent_loop.py
+++ b/backend/app/core/agent_loop.py
@@ -133,7 +133,18 @@ def _agent_identity_prompt(agent: AgentProfile) -> str:
         lines.append("")
         lines.append("员工角色补充要求：")
         lines.append(persona)
-    return "\n".join(lines)
+
+    rendered_values = []
+    for key2, label2 in AGENT_PERSONA_METADATA_FIELDS:
+        if label2 != label:
+            continue
+        v2 = _metadata_prompt_text(metadata.get(key2))
+        if v2 and v2 not in rendered_values:
+            rendered_values.append(v2)
+    combined = "".join(rendered_values) if rendered_values else value
+    lines.append(f"{label}:{combined}")
+    seen_labels.add(label)
+    continue    return "\n".join(lines)
 
 
 def _metadata_prompt_text(value: object) -> str:


### PR DESCRIPTION
## 问题描述

_agent_identity_prompt() 中 AGENT_PERSONA_METADATA_FIELDS 定义了多个 key 映射到同一个 label。当前去重逻辑直接跳过后续 key，导致 metadata 值被完全丢弃。

例如 role_name: Customer Support、position: Senior Support、job_title: Lead Support 都映射到 label 岗位，但输出仅包含 岗位：Customer Support。

## 影响范围

- 企业数字员工配置多个岗位相关 metadata 时，只有第一个字段被展示
- 所有同 label 的 metadata 字段受影响

## 修复

将同 label 的 metadata 值合并展示，不再跳过后续字段。

## UI 校验说明

本修复在 Prompt 构建层，输出的 prompt 字符串包含全量 metadata 值。UI 侧无需变更。

## 用户角色影响

管理员可维护多个同类型 metadata 字段，不再因字段冲突导致信息缺失。