### PR TITLE
fix: ChatTurnRequest.user_id 默认值不一致 (1行修复)

### DIFF
--- a/backend/app/session/session_schema.py
+++ b/backend/app/session/session_schema.py
@@ -144,7 +144,7 @@ class ChatTurnRequest(BaseModel):
     agent_id: Optional[str] = None
     model_config_id: Optional[str] = None
     client_turn_id: Optional[str] = None
-    user_id: str = ""
+    user_id: Optional[str] = None
     message: str
     attachments: list["ChatAttachmentRead"] = Field(default_factory=list)
     channel: str = "web"


### PR DESCRIPTION
## 问题描述

ChatTurnRequest.user_id 默认值为空字符串 ""，而 ChatSessionCreateRequest.user_id 默认值为 None。语义不统一："" 和 None 在 Pydantic 验证和数据库写入时有不同行为。

## 影响范围

- API 层可能会出现 "" 被写入 user_id 字段
- 数据库查询 user_id 时需要额外处理空字符串

## 修复

将 ChatTurnRequest.user_id 默认值改为 None，与 ChatSessionCreateRequest 一致。

## UI 校验说明

本次修改在 API Schema 层，不影响前端传参。前端在创建会话和发送消息时的 user_id 行为保持不变。

## 用户角色影响

无感知。