### PR TITLE
fix:_agent_identity_prompt_dedup

### DIFF
--- a/backend/app/core/agent_loop.py
+++ b/backend/app/core/agent_loop.py
@@ -126,7 +126,7 @@ def _agent_identity_prompt(agent: AgentProfile) -> str:
             continue
         if label not in label_values:
             label_values[label] = []
-            label_values[label].append(value)
+        label_values[label].append(value)
     for label, values in label_values.items():
         lines.append(f"{label}：{'; '.join(values)}")
     persona = str(agent.persona_prompt or "").strip()

--- a/backend/app/core/agent_loop.py
+++ b/backend/app/core/agent_loop.py
@@ -119,15 +119,16 @@ def _agent_identity_prompt(agent: AgentProfile) -> str:
     description = _single_line_text(agent.description)
     if description:
         lines.append(f"员工描述：{description}")
-    seen_labels: set[str] = set()
+    label_values: dict[str, list[str]] = {}
     for key, label in AGENT_PERSONA_METADATA_FIELDS:
         value = _metadata_prompt_text(metadata.get(key))
         if not value:
             continue
-        if label in seen_labels and label in {"岗位"}:
-            continue
-        seen_labels.add(label)
-        lines.append(f"{label}：{value}")
+        if label not in label_values:
+            label_values[label] = []
+            label_values[label].append(value)
+    for label, values in label_values.items():
+        lines.append(f"{label}：{'; '.join(values)}")
     persona = str(agent.persona_prompt or "").strip()
     if persona:
         lines.append("")

--- a/backend/app/core/agent_loop.py
+++ b/backend/app/core/agent_loop.py
@@ -128,7 +128,7 @@ def _agent_identity_prompt(agent: AgentProfile) -> str:
             label_values[label] = []
         label_values[label].append(value)
     for label, values in label_values.items():
-        lines.append(f"{label}：{'; '.join(values)}")
+        lines.append(f"{label}：{'；'.join(values)}")
     persona = str(agent.persona_prompt or "").strip()
     if persona:
         lines.append("")

--- a/backend/tests/test_agent_identity.py
+++ b/backend/tests/test_agent_identity.py
@@ -1,0 +1,39 @@
+import pytest
+
+from app.core.agent_loop import _agent_identity_prompt
+from app.db.models import AgentProfile
+
+
+def _make_agent(metadata, name, desc, persona):
+    agent=AgentProfile()
+    agent.metadata_json=metadata
+    agent.name=name
+    agent.description=desc
+    agent.persona_prompt=persona
+    return agent
+
+class TestAgentIdentityPrompt:
+    def test_single_label_single_value(self):
+        md={'role_name': '客服'}
+        a=_make_agent(md,'客服A','','')
+        result=_agent_identity_prompt(a)
+        assert '\u5c97\u4f4d\uff1a\u5ba2\u670d' in result
+
+    def test_dedup_merges_multi_values(self):
+        md={'role_name': '\u5ba2\u670d', 'position': '\u9ad8\u7ea7\u5ba2\u670d', 'job_title': '\u7ec4\u957f'}
+        a=_make_agent(md,'\u5ba2\u670dB','','')
+        result=_agent_identity_prompt(a)
+        assert '\u5c97\u4f4d\uff1a\u5ba2\u670d\uff1b\u9ad8\u7ea7\u5ba2\u670d\uff1b\u7ec4\u957f' in result
+
+    def test_partial_values_skip_empty(self):
+        md={'role_name': '\u5ba2\u670d', 'position': '', 'job_title': '\u7ec4\u957f'}
+        a=_make_agent(md,'\u5ba2\u670dC','','')
+        result=_agent_identity_prompt(a)
+        assert '\u5c97\u4f4d\uff1a\u5ba2\u670d\uff1b\u7ec4\u957f' in result
+        assert '\u5c97\u4f4d\uff1a\u5ba2\u670d\uff1b\uff1b\u7ec4\u957f' not in result
+
+    def test_empty_metadata_returns_persona(self):
+        a=_make_agent({},'\u6d4b\u8bd5Agent','','\u6211\u662f\u667a\u80fd\u52a9\u624b')
+        result=_agent_identity_prompt(a)
+        assert '\u6211\u662f\u667a\u80fd\u52a9\u624b' in result
+        assert '\u5c97\u4f4d' not in result


### PR DESCRIPTION
## 问题描述

_agent_identity_prompt() 使用 seen_labels: set[str] + continue 去重同名 label（岗位），
导致 role_name、position、job_title 三个字段映射到同一个 label 岗位时，
仅保留第一个值，后续字段值被丢弃。

## 影响范围

File: backend/app/core/agent_loop.py, backend/tests/test_agent_identity.py
Impact: Agent identity prompt drops role_name+position+job_title fields
Role: end users see incomplete agent introduction
LLM prompt: missing full position description chain

## 修复方式

Replace seen_labels: set[str]+continue with label_values: dict[str,list[str]]
collection + "; " join. 10 line replacement (-5 +11), no import changes.

## 测试策略

4 test cases:
- test_single_label_single_value: regression
- test_dedup_merges_multi_values: core fix verification
- test_partial_values_skip_empty: no empty placeholders
- test_empty_metadata_returns_persona: no crash

## UI 校验

Call chain: _agent_identity_prompt() - - /api/chat/send
Affects: end users (customer service), admin (agent detail), LLM prompt quality
