### PR TITLE
fix(security): use per-user random salt for PBKDF2 password hashing

### DIFF
--- a/backend/app/security/auth.py
+++ b/backend/app/security/auth.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import hmac
 import json
+import os
 import time
 from typing import Any
 
@@ -21,13 +22,19 @@ security = HTTPBearer(auto_error=False)
 
 
 def hash_password(password: str) -> str:
-    salt = hashlib.sha256(get_settings().app_secret.encode("utf-8")).hexdigest()[:16]
+    salt = os.urandom(16).hex()
     digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("utf-8"), 120_000)
     return f"pbkdf2_sha256${salt}${base64.urlsafe_b64encode(digest).decode('utf-8')}"
 
 
 def verify_password(password: str, stored_hash: str) -> bool:
-    return hmac.compare_digest(hash_password(password), stored_hash)
+    try:
+        _algo, salt, _digest = stored_hash.split("$", 2)
+    except ValueError:
+        return False
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("utf-8"), 120_000)
+    candidate = f"pbkdf2_sha256${salt}${base64.urlsafe_b64encode(digest).decode('utf-8')}"
+    return hmac.compare_digest(candidate, stored_hash)
 
 
 def create_access_token(user: User) -> str:

--- a/backend/tests/test_auth_password_hashing.py
+++ b/backend/tests/test_auth_password_hashing.py
@@ -1,0 +1,34 @@
+import base64
+import hashlib
+
+from app.security.auth import hash_password, verify_password
+
+
+def _legacy_hash(password: str, app_secret: str = "test-secret-key-for-legacy") -> str:
+    """Replicate the old hash_password() that derived salt from APP_SECRET."""
+    salt = hashlib.sha256(app_secret.encode("utf-8")).hexdigest()[:16]
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("utf-8"), 120_000)
+    return f"pbkdf2_sha256${salt}${base64.urlsafe_b64encode(digest).decode('utf-8')}"
+
+
+def test_same_password_produces_different_hashes() -> None:
+    h1 = hash_password("mypassword")
+    h2 = hash_password("mypassword")
+    assert h1 != h2
+
+
+def test_correct_password_accepted_and_wrong_rejected() -> None:
+    stored = hash_password("correcthorse")
+    assert verify_password("correcthorse", stored) is True
+    assert verify_password("wrongpassword", stored) is False
+
+
+def test_legacy_hash_verifies_with_new_verify() -> None:
+    old_hash = _legacy_hash("oldpassword")
+    assert verify_password("oldpassword", old_hash) is True
+    assert verify_password("wrongpassword", old_hash) is False
+
+
+def test_malformed_hash_returns_false() -> None:
+    assert verify_password("anypassword", "not-a-valid-hash") is False
+    assert verify_password("anypassword", "") is False


### PR DESCRIPTION
## Summary

Use a **per-user random salt** for PBKDF2 password hashing instead of a shared salt derived from `APP_SECRET`.

## Problem

`hash_password()` derived its salt from `sha256(APP_SECRET)[:16]`, meaning every user in the system shared the same salt. This significantly weakens PBKDF2 because an attacker can build a single rainbow table and crack all user passwords at once — defeating the entire purpose of per-user key stretching.

## Fix

- **`hash_password()`**: Generate a cryptographically random 16-byte salt via `os.urandom(16)` on each call.
- **`verify_password()`**: Parse the salt from the stored hash string (`pbkdf2_sha256$<salt>$<digest>`) instead of recomputing it from APP_SECRET, then verify against it.

## Backward Compatibility

**100% backward-compatible.** Existing hashes already embed their salt in the `pbkdf2_sha256$...$...` format. The new `verify_password()` simply reads the salt from the stored string, which works identically for both old (shared-salt) and new (random-salt) hashes.

- All existing users can log in without any migration.
- New passwords and admin password resets automatically get the stronger per-user salt.
- Auth tests pass unchanged.

## Security Impact

| Aspect | Before | After |
|--------|--------|-------|
| Salt source | `sha256(APP_SECRET)[:16]` | `os.urandom(16)` |
| Salt uniqueness | One salt for all users | Unique per user per hash |
| Rainbow table risk | Vulnerable | Protected |
| Side-channel | Timing-safe comparison ✓ | Timing-safe comparison ✓ |

## Testing

- Standalone tests verify: correct password, wrong password, unique salts for identical passwords, backward compat with old hashes, invalid format handling.
- `test_auth_roles.py` (2/2) passes.
- `test_general_skills.py` auth-related tests (28/28) pass; 8 pre-existing LLM-dependent failures are unrelated.