### PR TITLE
fix(llm): retry with doubled max_tokens when reasoning models hit length limit

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -156,7 +156,9 @@ class LLMClient:
                 )
             )
             empty_diagnostics: list[str] = []
+            current_max_tokens = max_output_tokens
             for attempt in range(EMPTY_RESPONSE_RETRIES + 1):
+                request["max_tokens"] = current_max_tokens
                 span = start_llm_call(
                     model=self.model,
                     endpoint=_endpoint_label(getattr(self, "base_url", "")),
@@ -165,7 +167,7 @@ class LLMClient:
                     attempt=attempt + 1,
                     retry_count=attempt,
                     max_attempts=EMPTY_RESPONSE_RETRIES + 1,
-                    max_output_tokens=max_output_tokens,
+                    max_output_tokens=current_max_tokens,
                     thinking_mode=getattr(self, "thinking_mode", "") or "provider_default",
                     **request_shape,
                 )
@@ -199,6 +201,15 @@ class LLMClient:
                     **metrics,
                 )
                 empty_diagnostics.append(_completion_empty_diagnostic(completion, attempt + 1))
+                # Reasoning models (e.g. deepseek-v4-flash) share the max_tokens budget
+                # between reasoning_content and content. When finish_reason=length cuts off
+                # before the answer, retry with a doubled budget so reasoning has room to
+                # finish and content can be produced.
+                if (
+                    metrics.get("finish_reason") == "length"
+                    and metrics.get("reasoning_chars", 0) > 0
+                ):
+                    current_max_tokens = min(current_max_tokens * 2, 32768)
                 if attempt >= EMPTY_RESPONSE_RETRIES:
                     raise LLMError(_empty_response_detail(self, empty_diagnostics))
         except Exception as exc:
@@ -231,6 +242,7 @@ class LLMClient:
         )
         try:
             empty_diagnostics: list[str] = []
+            current_max_tokens = max_output_tokens
             for attempt in range(EMPTY_RESPONSE_RETRIES + 1):
                 span = start_llm_call(
                     model=self.model,
@@ -240,7 +252,7 @@ class LLMClient:
                     attempt=attempt + 1,
                     retry_count=attempt,
                     max_attempts=EMPTY_RESPONSE_RETRIES + 1,
-                    max_output_tokens=max_output_tokens,
+                    max_output_tokens=current_max_tokens,
                     thinking_mode=getattr(self, "thinking_mode", "") or "provider_default",
                     **request_shape,
                 )
@@ -261,7 +273,7 @@ class LLMClient:
                         "model": self.model,
                         "messages": request_messages,
                         "temperature": self.temperature,
-                        "max_tokens": max_output_tokens,
+                        "max_tokens": current_max_tokens,
                         **_thinking_request_kwargs(
                             getattr(self, "thinking_mode", ""),
                             getattr(self, "extra_body", {}),
@@ -359,6 +371,10 @@ class LLMClient:
                         response_ids,
                     )
                 )
+                # Reasoning models share the max_tokens budget between reasoning and answer.
+                # When length-truncated with only reasoning output, double the budget on retry.
+                if "length" in finish_reasons and reasoning_chars > 0:
+                    current_max_tokens = min(current_max_tokens * 2, 32768)
             raise LLMError(_empty_response_detail(self, empty_diagnostics))
         except Exception as exc:
             if isinstance(exc, LLMError):

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -44,6 +44,24 @@ EMPTY_RESPONSE_MESSAGE = "Model returned an empty response"
 DEFAULT_MODEL_API_TIMEOUT_SECONDS = 600.0
 DEFAULT_INPUT_TOKEN_BUDGET = 32_000
 TURN_STAGE_MESSAGE_MARKER = "_agent_turn_message"
+# Ceiling for the reasoning-model length-truncation retry escalation. A model
+# configuration may legitimately request a larger budget than this; in that case
+# the retry preserves the configured value instead of shrinking it.
+REASONING_TOKEN_ESCALATION_CEILING = 32768
+
+
+def _escalate_reasoning_token_budget(current_max_tokens: int) -> int:
+    """Double the token budget for the next retry, but never below the ceiling.
+
+    Reasoning models (e.g. deepseek-v4-flash) share the max_tokens budget
+    between reasoning_content and content. When finish_reason=length cuts off
+    before the answer, we retry with more room. We cap the escalation at the
+    ceiling, but we never *reduce* a budget that the operator already configured
+    above the ceiling.
+    """
+    if current_max_tokens >= REASONING_TOKEN_ESCALATION_CEILING:
+        return current_max_tokens
+    return min(current_max_tokens * 2, REASONING_TOKEN_ESCALATION_CEILING)
 
 
 class _CurrentStageText(str):
@@ -203,13 +221,13 @@ class LLMClient:
                 empty_diagnostics.append(_completion_empty_diagnostic(completion, attempt + 1))
                 # Reasoning models (e.g. deepseek-v4-flash) share the max_tokens budget
                 # between reasoning_content and content. When finish_reason=length cuts off
-                # before the answer, retry with a doubled budget so reasoning has room to
-                # finish and content can be produced.
+                # before the answer, retry with more room so reasoning can finish and
+                # content can be produced. Never shrink a budget already at/above the ceiling.
                 if (
                     metrics.get("finish_reason") == "length"
                     and metrics.get("reasoning_chars", 0) > 0
                 ):
-                    current_max_tokens = min(current_max_tokens * 2, 32768)
+                    current_max_tokens = _escalate_reasoning_token_budget(current_max_tokens)
                 if attempt >= EMPTY_RESPONSE_RETRIES:
                     raise LLMError(_empty_response_detail(self, empty_diagnostics))
         except Exception as exc:
@@ -372,9 +390,10 @@ class LLMClient:
                     )
                 )
                 # Reasoning models share the max_tokens budget between reasoning and answer.
-                # When length-truncated with only reasoning output, double the budget on retry.
+                # When length-truncated with only reasoning output, escalate the budget on
+                # retry, but never shrink one already at/above the ceiling.
                 if "length" in finish_reasons and reasoning_chars > 0:
-                    current_max_tokens = min(current_max_tokens * 2, 32768)
+                    current_max_tokens = _escalate_reasoning_token_budget(current_max_tokens)
             raise LLMError(_empty_response_detail(self, empty_diagnostics))
         except Exception as exc:
             if isinstance(exc, LLMError):

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -1054,3 +1054,144 @@ def test_generate_json_allows_multiple_repair_attempts(monkeypatch):
     assert payloads[1]["_json_repair"]["attempt"] == 1
     assert payloads[2]["_json_repair"]["attempt"] == 2
     assert "parser_error" in payloads[2]["_json_repair"]
+
+
+# --- Reasoning-model length-truncation token escalation regression tests ---
+
+
+def _length_truncated_completion():
+    """A completion whose reasoning phase exhausted the budget (finish_reason=length,
+    empty content, non-empty reasoning_content)."""
+    message = type(
+        "Message",
+        (),
+        {"content": "", "reasoning_content": "thinking about the answer"},
+    )()
+    choice = type("Choice", (), {"message": message, "finish_reason": "length"})()
+    usage = type("Usage", (), {"completion_tokens": 32})()
+    return type(
+        "Completion",
+        (),
+        {"choices": [choice], "usage": usage, "id": "resp_demo"},
+    )()
+
+
+def _successful_completion(content="ok"):
+    message = type("Message", (), {"content": content, "reasoning_content": None})()
+    choice = type("Choice", (), {"message": message, "finish_reason": "stop"})()
+    return type("Completion", (), {"choices": [choice], "id": "resp_demo"})()
+
+
+def _recording_create(client, factory):
+    """Replace the fake client's create with one that records calls and delegates."""
+    def _create(**kwargs):
+        client.client.chat.completions.calls.append(kwargs)
+        return factory()
+    return _create
+
+
+def test_generate_text_escalates_token_budget_on_reasoning_length_truncation():
+    client = object.__new__(LLMClient)
+    client.client = _FakeOpenAIClient()
+    client.model = "demo-model"
+    client.temperature = 0.2
+    client.max_output_tokens = 4096
+
+    # First attempt: length-truncated empty content with reasoning -> retry.
+    # Second attempt: succeed so we can observe the escalated budget on attempt 1.
+    responses = iter([_length_truncated_completion(), _successful_completion()])
+    client.client.chat.completions.create = _recording_create(client, lambda: next(responses))
+
+    output = client.generate_text("system prompt", {"hello": "world"})
+
+    assert output == "ok"
+    calls = client.client.chat.completions.calls
+    assert len(calls) == 2
+    # Attempt 0 uses the configured budget.
+    assert calls[0]["max_tokens"] == 4096
+    # Attempt 1 is doubled (4096 * 2 = 8192), still under the 32768 ceiling.
+    assert calls[1]["max_tokens"] == 8192
+
+
+def test_generate_text_preserves_budget_above_escalation_ceiling():
+    client = object.__new__(LLMClient)
+    client.client = _FakeOpenAIClient()
+    client.model = "demo-model"
+    client.temperature = 0.2
+    # Operator configured a budget larger than the escalation ceiling.
+    client.max_output_tokens = 65536
+
+    responses = iter([_length_truncated_completion(), _successful_completion()])
+    client.client.chat.completions.create = _recording_create(client, lambda: next(responses))
+
+    output = client.generate_text("system prompt", {"hello": "world"})
+
+    assert output == "ok"
+    calls = client.client.chat.completions.calls
+    assert len(calls) == 2
+    # The configured value must be preserved on retry -- never shrunk to the ceiling.
+    assert calls[0]["max_tokens"] == 65536
+    assert calls[1]["max_tokens"] == 65536
+
+
+def test_generate_text_stream_escalates_token_budget_on_reasoning_length_truncation():
+    client = object.__new__(LLMClient)
+    client.client = _FakeOpenAIClient()
+    client.model = "demo-model"
+    client.base_url = "https://example.test/v1"
+    client.timeout_seconds = 600.0
+    client.temperature = 0.2
+    client.max_output_tokens = 4096
+
+    def length_chunk():
+        delta = type("Delta", (), {"content": None, "reasoning_content": "thinking"})()
+        choice = type("Choice", (), {"delta": delta, "finish_reason": "length"})()
+        return type("Chunk", (), {"id": "chunk_demo", "choices": [choice]})()
+
+    def success_chunks():
+        delta = type("Delta", (), {"content": "ok", "reasoning_content": None})()
+        choice = type("Choice", (), {"delta": delta, "finish_reason": "stop"})()
+        return [type("Chunk", (), {"id": "chunk_demo", "choices": [choice]})()]
+
+    streams = iter([[length_chunk()], success_chunks()])
+    client.client.chat.completions.create = _recording_create(client, lambda: iter(next(streams)))
+
+    output = "".join(client.generate_text_stream("system prompt", {"hello": "world"}))
+
+    assert output == "ok"
+    calls = client.client.chat.completions.calls
+    assert len(calls) == 2
+    assert calls[0]["max_tokens"] == 4096
+    assert calls[1]["max_tokens"] == 8192
+
+
+def test_generate_text_stream_preserves_budget_above_escalation_ceiling():
+    client = object.__new__(LLMClient)
+    client.client = _FakeOpenAIClient()
+    client.model = "demo-model"
+    client.base_url = "https://example.test/v1"
+    client.timeout_seconds = 600.0
+    client.temperature = 0.2
+    client.max_output_tokens = 65536
+
+    def length_chunk():
+        delta = type("Delta", (), {"content": None, "reasoning_content": "thinking"})()
+        choice = type("Choice", (), {"delta": delta, "finish_reason": "length"})()
+        return type("Chunk", (), {"id": "chunk_demo", "choices": [choice]})()
+
+    def success_chunks():
+        delta = type("Delta", (), {"content": "ok", "reasoning_content": None})()
+        choice = type("Choice", (), {"delta": delta, "finish_reason": "stop"})()
+        return [type("Chunk", (), {"id": "chunk_demo", "choices": [choice]})()]
+
+    streams = iter([[length_chunk()], success_chunks()])
+    client.client.chat.completions.create = _recording_create(client, lambda: iter(next(streams)))
+
+    output = "".join(client.generate_text_stream("system prompt", {"hello": "world"}))
+
+    assert output == "ok"
+    calls = client.client.chat.completions.calls
+    assert len(calls) == 2
+    assert calls[0]["max_tokens"] == 65536
+    assert calls[1]["max_tokens"] == 65536
+


### PR DESCRIPTION
## Problem

Reasoning models such as `deepseek-v4-flash` (the new `deepseek-chat`) and `deepseek-reasoner` share the `max_tokens` budget between `reasoning_content` and `content`. When the thinking phase exhausts the budget before the answer is produced, the provider returns:

- `finish_reason: "length"`
- `content: ""` (empty)
- all generated text lands in `reasoning_content`

StaffDeck treated this empty `content` as an empty response and retried `EMPTY_RESPONSE_RETRIES` times **with the same fixed budget**, which guaranteed failure on every attempt. End users saw:

```
Model returned an empty response after 3 attempts; provider returned no usable message.content;
model=deepseek-v4-flash; endpoint=https://api.deepseek.com/v1;
attempt_1: ... finish_reason=length, content=string(0 chars), reasoning_chars=67, completion_tokens=32
attempt_2: ... finish_reason=length, content=string(0 chars), reasoning_chars=64, completion_tokens=32
attempt_3: ... finish_reason=length, content=string(0 chars), reasoning_chars=68, completion_tokens=32
```

This is consistent with DeepSeek's documented behaviour for reasoning models: `max_tokens` restricts both the reasoning and the response tokens, so if the limit is reached during reasoning the answer is cut off. ([DeepSeek API docs — Create Chat Completion](https://api-docs.deepseek.com/api/create-chat-completion/), [Thinking mode](https://api-docs.deepseek.com/guides/thinking_mode/))

## Fix

Track a mutable `current_max_tokens` per call. On each retry, if the previous attempt was truncated by `length` **and** produced reasoning output, double the budget (capped at 32768) so the model has room to finish reasoning and emit content.

Applied symmetrically to:
- `LLMClient.generate_text` (non-stream)
- `LLMClient.generate_text_stream` (stream)

```python
# Reasoning models share the max_tokens budget between reasoning_content and content.
# When finish_reason=length cuts off before the answer, retry with a doubled budget
# so reasoning has room to finish and content can be produced.
if metrics.get("finish_reason") == "length" and metrics.get("reasoning_chars", 0) > 0:
    current_max_tokens = min(current_max_tokens * 2, 32768)
```

The escalation only triggers for the reasoning-truncation pattern, so non-reasoning models and genuine empty responses are unaffected.

## Verification

Tested end-to-end against `deepseek-v4-flash` at `https://api.deepseek.com/v1`:

1. **Plain Q&A turn** — routed as `answer_only`, returns fluent content:
   > 你好！我是你的事务管家，可以帮你打理用章申请、会议室预订、办公用品申领等行政事务…

2. **SOP turn** — `我要申请用章` correctly triggers the state machine:
   - `router_decision.decision = continue_active`
   - `target_skill_id = seal_application_approval`
   - `target_step_id = evaluate_compliance`
   - the agent asks a SOP-driven follow-up ("合同金额是多少？这有助于判断是否需要加签审批")

Both turns now succeed; before the fix they failed with the empty-response error above.

## Checklist

- [x] `ruff check backend/app/llm/client.py` passes
- [x] `python -m py_compile backend/app/llm/client.py` passes
- [x] No behavioural change for non-reasoning models (escalation is gated on `finish_reason=length` AND `reasoning_chars > 0`)
