### PR TITLE
fix(channels): 群聊止血——企微 is_group 以 chattype 为准，群记忆红线（不写不读）

### DIFF
--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -22,6 +22,7 @@ from app.channels import (
     resume_binding_ingress,
     wait_binding_ingress_stopped,
 )
+from app.channels.adapters.base import is_group_conv_id
 from app.channels.adapters.dingtalk import (
     DingTalkPermanentError,
     validate_dingtalk_credentials,
@@ -1343,7 +1344,6 @@ def list_channel_conversations(
         ).all()
         message_counts = {session_id: count for session_id, count in count_rows}
 
-    group_prefix = f"{binding.channel}_group_"
     conversations: list[ChannelConversationRead] = []
     for chat_session in page:
         last_message = db.exec(
@@ -1359,7 +1359,9 @@ def list_channel_conversations(
                 external_conv_id=external_conv_id,
                 display_name=identity_names.get(chat_session.user_id)
                 or user_names.get(chat_session.user_id),
-                is_group=bool(external_conv_id and external_conv_id.startswith(group_prefix)),
+                is_group=bool(
+                    external_conv_id and is_group_conv_id(binding.channel, external_conv_id)
+                ),
                 agent_id=chat_session.agent_id,
                 agent_name=agent_name_map.get(chat_session.agent_id),
                 message_count=message_counts.get(chat_session.id, 0),

--- a/backend/app/channels/adapters/base.py
+++ b/backend/app/channels/adapters/base.py
@@ -115,11 +115,14 @@ def is_group_conv_id(channel: str, external_conv_id: str) -> bool:
 
     兼容三种格式:无 scope 的 {channel}_group_x、带 scope 的 {channel}_{scope}_group_x、
     以及成员级 {channel}_{scope}_group_x#member;不看 channel 之后的 scope 内容。
+    先排除私聊:p2p 的用户 ID 可能含 "_group_"(如 user_group_alice),仅按子串判群会误判。
     """
     prefix = f"{channel}_"
     if not external_conv_id.startswith(prefix):
         return False
     rest = external_conv_id[len(prefix):]
+    if rest.startswith("p2p_") or "_p2p_" in rest:
+        return False
     return rest.startswith("group_") or "_group_" in rest
 
 

--- a/backend/app/channels/adapters/base.py
+++ b/backend/app/channels/adapters/base.py
@@ -110,6 +110,19 @@ class ChannelInbound:
         return f"{self.channel}_p2p_{self.from_user_id}"
 
 
+def is_group_conv_id(channel: str, external_conv_id: str) -> bool:
+    """判定 external_conv_id 是否为群会话。
+
+    兼容三种格式:无 scope 的 {channel}_group_x、带 scope 的 {channel}_{scope}_group_x、
+    以及成员级 {channel}_{scope}_group_x#member;不看 channel 之后的 scope 内容。
+    """
+    prefix = f"{channel}_"
+    if not external_conv_id.startswith(prefix):
+        return False
+    rest = external_conv_id[len(prefix):]
+    return rest.startswith("group_") or "_group_" in rest
+
+
 class ChannelAdapter(Protocol):
     """渠道适配器协议:归一化 + 出站 + 可选 typing + ingress 生命周期。"""
 

--- a/backend/app/channels/adapters/wecom.py
+++ b/backend/app/channels/adapters/wecom.py
@@ -187,11 +187,11 @@ def normalize_wecom_frame(frame: dict[str, Any], *, account_scope: str = "") -> 
     chat_id = str(body.get("chatid") or "").strip()
     chattype = str(body.get("chattype") or "").strip()
     if chattype == "group" and not chat_id:
-        # 群消息缺 chatid 时按私聊降级,避免群会话退化为每人一个会话
-        logger.warning("企微群消息缺少 chatid,按私聊降级处理 msgid=%s", body.get("msgid"))
-        chattype = "single"
-    # 官方文档：chatid 仅群聊返回
-    is_group = bool(chat_id)
+        # 群消息缺 chatid 无法构成稳定群会话:丢弃,绝不降级混入成员私聊会话
+        logger.warning("企微群消息缺少 chatid,丢弃 msgid=%s", body.get("msgid"))
+        return None
+    # 以 chattype 为准(官方文档 chatid 仅群聊返回,但字段存在性不等于会话类型)
+    is_group = chattype == "group"
     headers = frame.get("headers") or {}
     event_id = str(body.get("msgid") or body.get("msg_id") or headers.get("req_id") or "").strip()
     if not event_id:
@@ -202,10 +202,10 @@ def normalize_wecom_frame(frame: dict[str, Any], *, account_scope: str = "") -> 
         event_id=event_id,
         from_user_id=from_user_id,
         to_user_id=str(body.get("aibotid") or "").strip(),
-        session_id=chat_id or from_user_id,
-        group_id=chat_id,
+        session_id=(chat_id or from_user_id) if is_group else from_user_id,
+        group_id=chat_id if is_group else "",
         # 企微无 context_token 概念：发送仅需 chatid，占位保持内核必填语义
-        context_token=chat_id or from_user_id,
+        context_token=(chat_id or from_user_id) if is_group else from_user_id,
         text=text,
         is_group=is_group,
         raw=frame,

--- a/backend/app/core/harness_v2_engine.py
+++ b/backend/app/core/harness_v2_engine.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sqlalchemy.exc import IntegrityError
 
+from app.channels.adapters.base import is_group_conv_id
 from app.core.cancellation import is_chat_turn_cancelled
 from app.core.capability_discovery import project_capability_manifest
 from app.core.capability_manifest import CapabilityManifestBuilder
@@ -279,14 +280,19 @@ class HarnessV2Engine:
         self.owner._drop_unavailable_skill_state(
             request.tenant_id, session, skills
         )
-        memory_context = [
-            memory_read(row)
-            for row in self.owner.memory.context_memories(
-                request.tenant_id,
-                request.user_id,
-                agent_id=session.agent_id,
-            )
-        ]
+        # 群记忆红线:群聊会话不检索个人记忆(私人偏好绝不在群里被念出来)
+        memory_context = (
+            []
+            if is_group_conv_id(session.channel or "", session.external_conv_id or "")
+            else [
+                memory_read(row)
+                for row in self.owner.memory.context_memories(
+                    request.tenant_id,
+                    request.user_id,
+                    agent_id=session.agent_id,
+                )
+            ]
+        )
         if memory_context:
             self.events.record(
                 request.tenant_id,

--- a/backend/app/memory/jobs.py
+++ b/backend/app/memory/jobs.py
@@ -5,6 +5,7 @@ from typing import Any
 from sqlmodel import Session, select
 
 from app.async_jobs import AsyncJob, enqueue_async_job
+from app.channels.adapters.base import is_group_conv_id
 from app.db import engine
 from app.db.models import AgentEvent, ChatSession, Message, ModelConfig
 from app.memory.service import MemoryService, memory_read
@@ -62,6 +63,9 @@ def run_memory_capture_job(payload: dict[str, Any]) -> None:
                 },
             )
             db.commit()
+            return
+        # 群记忆红线:群聊会话不沉淀任何记忆(成员隐私不得混入群账号/跨成员共享)
+        if is_group_conv_id(chat_session.channel or "", chat_session.external_conv_id or ""):
             return
 
         user_events = db.exec(

--- a/backend/tests/test_channel_wechat.py
+++ b/backend/tests/test_channel_wechat.py
@@ -1065,3 +1065,18 @@ def test_chunk_client_id_carries_chunk_index() -> None:
     random_ids = [payload["msg"]["client_id"] for payload in sent]
     assert len(set(random_ids)) == 3
     assert all(not cid.startswith("staffdeck:msg_1") for cid in random_ids)
+
+
+def test_is_group_conv_id_formats() -> None:
+    from app.channels.adapters.base import is_group_conv_id
+
+    # 无 scope 旧格式 / 带 scope / 成员级(#member)三种群格式均判真
+    assert is_group_conv_id("wechat", "wechat_group_room_1") is True
+    assert is_group_conv_id("wecom", "wecom_corpA_group_wr_1") is True
+    assert is_group_conv_id("wecom", "wecom_corpA_group_wr_1#zhangsan") is True
+    assert is_group_conv_id("feishu", "feishu_group_oc_1:thread:ot_1") is True
+    # 私聊不误判
+    assert is_group_conv_id("wechat", "wechat_p2p_user_1") is False
+    assert is_group_conv_id("wecom", "wecom_corpA_p2p_zhangsan") is False
+    # channel 不匹配不误判
+    assert is_group_conv_id("wechat", "wecom_group_wr_1") is False

--- a/backend/tests/test_channel_wechat.py
+++ b/backend/tests/test_channel_wechat.py
@@ -1078,5 +1078,8 @@ def test_is_group_conv_id_formats() -> None:
     # 私聊不误判
     assert is_group_conv_id("wechat", "wechat_p2p_user_1") is False
     assert is_group_conv_id("wecom", "wecom_corpA_p2p_zhangsan") is False
+    # 私聊用户 ID 含 "_group_" 也不能误判为群(评审案例)
+    assert is_group_conv_id("wechat", "wechat_p2p_user_group_alice") is False
+    assert is_group_conv_id("wecom", "wecom_corpA_p2p_user_group_bob") is False
     # channel 不匹配不误判
     assert is_group_conv_id("wechat", "wecom_group_wr_1") is False

--- a/backend/tests/test_channel_wecom.py
+++ b/backend/tests/test_channel_wecom.py
@@ -1873,22 +1873,29 @@ def test_worker_retirement_and_reconcile_rebuild(monkeypatch) -> None:
     manager.stop_binding(binding_id)
 
 
-def test_group_without_chatid_degrades_to_p2p_with_warning(caplog) -> None:
+def test_group_without_chatid_dropped_with_warning(caplog) -> None:
     import logging
 
     frame = _text_frame(chattype="group", chatid="")
     with caplog.at_level(logging.WARNING, logger="app.channels.adapters.wecom"):
         inbound = normalize_wecom_frame(frame)
-    assert inbound is not None
-    # chattype=group 但缺 chatid:降级私聊,不退化为"每人一个群会话"
-    assert inbound.is_group is False
-    assert inbound.external_conv_id == "wecom_p2p_zhangsan"
+    # chattype=group 但缺 chatid:无法构成稳定群会话,丢弃,绝不降级混入私聊
+    assert inbound is None
     assert any("缺少 chatid" in record.message for record in caplog.records)
 
     # 有 chatid 的群形态不变
     group = normalize_wecom_frame(_text_frame(chatid="wr_1", chattype="group"))
     assert group is not None and group.is_group is True
     assert group.external_conv_id == "wecom_group_wr_1"
+
+
+def test_single_chattype_with_chatid_is_p2p() -> None:
+    """chattype=single 却带 chatid 的异常帧:以 chattype 为准按私聊处理。"""
+    inbound = normalize_wecom_frame(_text_frame(chattype="single", chatid="wr_ignored"))
+    assert inbound is not None
+    assert inbound.is_group is False
+    assert inbound.group_id == ""
+    assert inbound.external_conv_id == "wecom_p2p_zhangsan"
 
 
 # ---------- 断开超时主动告警 ----------

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -2,7 +2,16 @@ from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from app.api.memories import clear_my_memories, list_memories
-from app.db.models import AgentProfile, ChatSession, MemoryRecord, Message, ModelConfig, Tenant, User
+from app.db.models import (
+    AgentEvent,
+    AgentProfile,
+    ChatSession,
+    MemoryRecord,
+    Message,
+    ModelConfig,
+    Tenant,
+    User,
+)
 from app.llm.client import LLMClient
 from app.memory.jobs import _conversation_messages_for_turn
 from app.memory.service import MemoryService, memory_rows_for_read
@@ -507,3 +516,105 @@ def _test_session() -> Session:
     )
     SQLModel.metadata.create_all(engine)
     return Session(engine)
+
+
+def test_memory_job_skips_group_sessions(monkeypatch) -> None:
+    """群记忆红线:群聊会话的后台记忆任务直接跳过,不调用 capture、不写入。"""
+    from app.memory.jobs import run_memory_capture_job
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as db:
+        db.add(Tenant(id="tenant_demo", name="Demo"))
+        db.add(
+            ModelConfig(
+                id="model_1",
+                tenant_id="tenant_demo",
+                name="m",
+                model="gpt-x",
+                api_key_encrypted="x",
+            )
+        )
+        db.add(
+            ChatSession(
+                id="s_group",
+                tenant_id="tenant_demo",
+                user_id="user_group",
+                agent_id="agent_1",
+                channel="wecom",
+                external_conv_id="wecom_corpA_group_wr_1",
+            )
+        )
+        db.add(
+            ChatSession(
+                id="s_p2p",
+                tenant_id="tenant_demo",
+                user_id="user_web",
+                agent_id="agent_1",
+                channel="wecom",
+                external_conv_id="wecom_corpA_p2p_zhangsan",
+            )
+        )
+        db.commit()
+    monkeypatch.setattr("app.memory.jobs.engine", engine)
+    calls: list[str] = []
+
+    def fake_capture(self, request, chat_session, step_result, tool_result, model_config, messages):  # noqa: ANN001
+        calls.append(chat_session.id)
+        return []
+
+    monkeypatch.setattr(MemoryService, "capture_turn", fake_capture)
+
+    with Session(engine) as db:
+        # 私聊会话补一条用户消息事件与对应消息历史(capture 前置要求)
+        db.add(
+            AgentEvent(
+                tenant_id="tenant_demo",
+                session_id="s_p2p",
+                event_type="user_message_received",
+                payload_json={"turn_id": "t1"},
+            )
+        )
+        db.add(
+            Message(
+                tenant_id="tenant_demo",
+                session_id="s_p2p",
+                role="user",
+                content="hi",
+                metadata_json={"turn_id": "t1"},
+            )
+        )
+        db.add(
+            Message(
+                tenant_id="tenant_demo",
+                session_id="s_p2p",
+                role="assistant",
+                content="你好",
+                metadata_json={"turn_id": "t1"},
+            )
+        )
+        db.commit()
+
+    def _payload(session_id: str) -> dict:
+        return {
+            "request": ChatTurnRequest(
+                tenant_id="tenant_demo", message="hi", user_id="u", agent_id="agent_1"
+            ).model_dump(mode="json"),
+            "session_id": session_id,
+            "model_config_id": "model_1",
+            "step_result": StepAgentResult().model_dump(mode="json"),
+            "tool_result": None,
+        }
+
+    # 群会话:跳过
+    run_memory_capture_job(_payload("s_group"))
+    assert calls == []
+    with Session(engine) as db:
+        assert db.exec(select(MemoryRecord)).all() == []
+    # 私聊会话:正常进入 capture(不误伤)
+    run_memory_capture_job(_payload("s_p2p"))
+    assert calls == ["s_p2p"]


### PR DESCRIPTION
## 概述

「群聊 + 多数字员工沟通 + 分工」系列的**第 1 个 PR（止血包）**，先拆掉两个上线即炸的雷，后续 PR（成员级群聊/转派/分工编排）以此为基。

## 问题

1. **企微群消息误归类**(`wecom.py`):`chattype=group` 但缺 `chatid` 的异常帧被静默降级为私聊，真实群消息混入该成员的 p2p 会话（回复还会私聊发出）;`is_group` 仅看 `chatid` 存在性，`chattype=single` 却带 `chatid` 的帧会被误判为群。
2. **群记忆混忆（隐私级）**:群聊会话把所有成员映射到同一个"群账号"，后台记忆任务照常沉淀、检索照常命中——张三在群里说的偏好可能被回给李四。

## 修复

- **企微 `is_group` 以 `chattype` 为准**：缺 `chatid` 的群帧记 warning 后**丢弃**（无法构成稳定群会话，绝不降级混入私聊）;`single` 带 `chatid` 按私聊处理（`session_id/group_id/context_token` 同步按 is_group 归位）。
- **群记忆红线（不写不读）**:
  - 写：`memory/jobs.py` 后台任务拿到会话后，群会话直接跳过（零 LLM 开销，单一入口覆盖全部触发路径）;
  - 读：`agent_loop.py` 两处 `context_memories` 调用点，群会话跳过检索——成员私人偏好绝不会在群里被念出来;
  - 私聊行为完全不变。
- **新增 `is_group_conv_id(channel, conv_id)`**：兼容无 scope（`wechat_group_x`)、带 scope（`wecom_{corp}_group_x`)、成员级（`...#member`，为后续 PR 预留）三种格式；并顺带修复会话列表接口漏判带 scope 企微群（`is_group` 一直为 False）的既有瑕疵。

## 测试

- 企微：缺 `chatid` 群帧→None+warning;single 带 `chatid`→私聊（新行为固化）;
- `is_group_conv_id`：三种群格式判真、私聊/跨渠道不误判;
- 记忆红线：群会话后台任务不调用 capture、无任何写入；私聊会话正常进入 capture（不误伤）;
- 全量 **1205 passed**、ruff 零告警（唯一失败为 main 预存在的 `test_verification_runs_bounded_text_stream_and_json_probes`，与本 PR 无关）。

## 兼容性

- 无 schema 变更；存量群会话/记忆保留只读，不迁移不删除；
- 私聊、绑定、自动分发全链路无行为变化。