### PR TITLE
fix(scripts): stop native stderr from aborting dev.ps1 on Windows

### DIFF
--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -15,11 +15,17 @@ $candidates = @(
   [pscustomobject]@{ File = "python"; Prefix = @() }
 )
 
+# Native commands below write to stderr on benign paths: `py -3.11` when that
+# runtime is absent, and vite build warnings relayed by dev.py. Under
+# $ErrorActionPreference = "Stop" those surface as a terminating
+# NativeCommandError, so rely on exit codes for the rest of the script.
+$ErrorActionPreference = "Continue"
+
 $python = $null
 foreach ($candidate in $candidates) {
   if (-not $candidate.File) { continue }
   if (-not (Get-Command $candidate.File -ErrorAction SilentlyContinue)) { continue }
-  & $candidate.File @($candidate.Prefix) -c "import sys; assert sys.version_info >= (3, 11)" 2>$null
+  & $candidate.File @($candidate.Prefix) -c "import sys; assert sys.version_info >= (3, 11)" 2>&1 | Out-Null
   if ($LASTEXITCODE -eq 0) {
     $python = $candidate
     break


### PR DESCRIPTION
## Problem

On Windows PowerShell 5.1, `$ErrorActionPreference = "Stop"` promotes *any* stderr output from a native command into a terminating `NativeCommandError`. This broke `dev_up.ps1` in two separate places:

1. **Interpreter probe** — `py -3.11` writes `No suitable Python runtime found` to stderr on hosts without 3.11, aborting the candidate loop before `py -3` and `python` were ever tried. Setup then failed with `Python 3.11 or newer is required` despite a newer interpreter being installed.
2. **`dev.py` invocation (line 44)** — vite build warnings relayed on stderr aborted startup partway through, leaving no services running and a bare exit code 1.

The second one is the more confusing failure mode: `dev_up.ps1` exits 1 with essentially no diagnostic output.

## Fix

Set `$ErrorActionPreference = "Continue"` once before the native calls and rely on exit codes instead, and silence the probe with `2>&1 | Out-Null`.

- `throw` still terminates regardless of the preference, so the explicit "Python 3.11 or newer is required" guard is unaffected.
- `exit $LASTEXITCODE` keeps propagating real failures.

Since `dev_up.ps1`, `dev_down.ps1` and `dev_status.ps1` are all one-line wrappers around `dev.ps1`, this single change fixes all three.

## Verification

Windows PowerShell 5.1, Python 3.12.10 installed, **no 3.11 present**, no `PYTHON` override:

- `scripts\dev_up.ps1 --detach` -> exit 0, supervisor starts
- `scripts\dev_status.ps1` -> exit 0
- `scripts\dev_down.ps1` -> exit 0
- Full `down` -> `up` -> `status` cycle repeated, all exit 0
- `GET /api/health` -> `200 {"status":"ok","app":"StaffDeck"}`
- `GET /chat/`, `/enterprise/dashboard`, `/workspace/gallery` -> all 200

Before this change, `dev_up.ps1` failed on the same machine unless `$env:PYTHON` was set manually.

## Note

`scripts/dev_supervisor.py` resolves the backend interpreter from `backend/.venv` via `_backend_python()`, independently of whichever interpreter launches `dev.py`. So relaxing the probe does not risk running the backend under an unintended Python.
