### PR TITLE
feat(macos): support Intel builds with native embedded UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,10 @@ jobs:
         include:
           - os: macos-15        # Apple Silicon (arm64)
             script: bash packaging/build_macos.sh
+            macos_arch: arm64
           - os: macos-15-intel  # Intel (x86_64) — 无本地机器，靠 CI 出包
             script: bash packaging/build_macos.sh
+            macos_arch: x86_64
           - os: ubuntu-latest
             script: bash packaging/build_linux.sh
           - os: windows-latest
@@ -118,6 +120,7 @@ jobs:
       - name: Build
         env:
           VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+          STAFFDECK_MACOS_ARCH: ${{ matrix.macos_arch }}
         run: ${{ matrix.script }}
 
       - name: Windows general-skill smoke (python runtime)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+StaffDeck combines a Python 3.11+ FastAPI service with a React/TypeScript console. Backend application code lives in `backend/app/`; entry points such as `backend/single_port_app.py` support the desktop and single-port runtime. Backend tests are in `backend/tests/`, including contract-focused suites under `backend/tests/agent_golden/`. Frontend code is in `frontend-enterprise/src/`, with static assets in `frontend-enterprise/public/` and colocated `*.test.ts` or `*.test.tsx` files. Agent protocol fixtures and schemas belong in `contracts/agent/v1/`. Use `scripts/` for development lifecycle tooling and `packaging/` for platform release assets.
+
+## Build, Test, and Development Commands
+
+- `python3 -m venv backend/.venv && backend/.venv/bin/python -m pip install -e "backend[dev]"` installs backend and test dependencies.
+- `npm --prefix frontend-enterprise ci` installs the locked frontend dependencies.
+- `scripts/dev_up.sh --detach` builds the frontend and starts the single-port app; use `scripts/dev_status.sh` and `scripts/dev_down.sh` to inspect or stop it.
+- `backend/.venv/bin/python -m pytest backend/tests` runs the backend suite.
+- `backend/.venv/bin/ruff check backend` checks Python style.
+- `npm --prefix frontend-enterprise test` runs Vitest; `npm --prefix frontend-enterprise run build` performs TypeScript checking and the production Vite build.
+- Run `i18n:check` and `config:check` from `frontend-enterprise` when changing UI text or Vite environment usage.
+
+## Coding Style & Naming Conventions
+
+Python uses four-space indentation, type hints, `snake_case` functions/modules, and `PascalCase` classes; Ruff targets Python 3.11 with a 100-character line limit. TypeScript is strict and follows the existing two-space, single-quote, semicolon style. Name React components in `PascalCase`, hooks with `use...`, and tests after the unit under test. Prefer the `@/` alias for frontend imports.
+
+## Testing Guidelines
+
+Name Python tests `test_*.py` and frontend tests `*.test.ts(x)`. Add focused regression tests for behavior changes, especially permissions, persistence, streaming, and channel routing. No numeric coverage threshold is configured; changed paths should still be exercised. For UI changes, also verify the affected route and user role in a browser.
+
+## Commit & Pull Request Guidelines
+
+Follow the history’s concise Conventional Commit pattern, such as `feat(channels): add binding status` or `fix: reject unsafe avatar URLs`. Keep commits focused. Pull requests should explain intent and risk, link relevant issues, list tests run, and identify routes and roles used for UI validation. Include screenshots for visible changes and preserve unrelated worktree changes.
+
+## Security & Configuration
+
+Copy `backend/.env.example` to `backend/.env`; never commit secrets or channel credentials. Use strong `APP_SECRET` values and least-privilege external credentials. The supported production migration path currently assumes SQLite.
+
+## Agent skills
+
+### Issue tracker
+
+Do not create or manage issues for this repository. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Issue triage labels are not used. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Use the single-context documentation layout. See `docs/agents/domain.md`.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Visit the [StaffDeck official website](https://staffdeck.openbmb.cn/) or downloa
 | Platform | Architecture | Download |
 | --- | --- | --- |
 | macOS | Apple Silicon (arm64) | [Download `.dmg`](https://github.com/OpenBMB/StaffDeck/releases/latest/download/StaffDeck-macos-arm64.dmg) |
+| macOS | Intel (x86_64) | [Download `.dmg`](https://github.com/OpenBMB/StaffDeck/releases/latest/download/StaffDeck-macos-x86_64.dmg) |
 | Windows | x64 | [Download installer `.exe`](https://github.com/OpenBMB/StaffDeck/releases/latest/download/StaffDeck-windows-x64-setup.exe) |
 | Linux | x86_64 (Debian/Ubuntu) | [Download `.deb`](https://github.com/OpenBMB/StaffDeck/releases/latest/download/StaffDeck-linux-x86_64.deb) |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -43,6 +43,7 @@ StaffDeck是一套面向企业的数字员工构建与管理平台，帮助专�
 | 平台 | 架构 | 下载 |
 | --- | --- | --- |
 | macOS | Apple Silicon（arm64） | [下载 `.dmg`](https://github.com/OpenBMB/StaffDeck/releases/latest/download/StaffDeck-macos-arm64.dmg) |
+| macOS | Intel（x86_64） | [下载 `.dmg`](https://github.com/OpenBMB/StaffDeck/releases/latest/download/StaffDeck-macos-x86_64.dmg) |
 | Windows | x64 | [下载安装程序 `.exe`](https://github.com/OpenBMB/StaffDeck/releases/latest/download/StaffDeck-windows-x64-setup.exe) |
 | Linux | x86_64（Debian/Ubuntu） | [下载 `.deb`](https://github.com/OpenBMB/StaffDeck/releases/latest/download/StaffDeck-linux-x86_64.deb) |
 

--- a/backend/desktop_launcher.py
+++ b/backend/desktop_launcher.py
@@ -186,8 +186,7 @@ def _open_browser_when_ready(url: str) -> None:
 
 
 def _open_browser(target: str) -> None:
-    """打开浏览器页面。点 Dock 图标每次都开一个新标签——最稳定、跨浏览器一致、
-    不依赖 macOS 自动化授权（adhoc 签名下自动化授权弹窗不可靠）。"""
+    """Open StaffDeck in the system browser on platforms without an embedded window."""
     webbrowser.open(target)
 
 
@@ -199,8 +198,9 @@ def _four_char_code(value: str) -> int:
 
 
 def _use_macos_dock_app() -> bool:
-    # 仅 macOS 打包态用 Cocoa 壳（进 Dock + 点图标开页面）。
-    # 开发态 / 其它平台保持简单主线程 uvicorn。
+    if _env_flag("STAFFDECK_HEADLESS"):
+        return False
+    # 仅 macOS 打包态用 Cocoa 壳和内嵌 WebView。
     return sys.platform == "darwin" and getattr(sys, "frozen", False)
 
 
@@ -252,9 +252,41 @@ def preload_server_app(cfg: dict) -> None:
     cfg["app"] = getattr(module, attribute_name)
 
 
+def _create_macos_webview_window(AppKit, Foundation, WebKit, target: str):
+    """Create the native macOS window used by both arm64 and x86_64 bundles."""
+    style = (
+        AppKit.NSWindowStyleMaskTitled
+        | AppKit.NSWindowStyleMaskClosable
+        | AppKit.NSWindowStyleMaskMiniaturizable
+        | AppKit.NSWindowStyleMaskResizable
+    )
+    window = AppKit.NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
+        AppKit.NSMakeRect(0, 0, 1280, 800),
+        style,
+        AppKit.NSBackingStoreBuffered,
+        False,
+    )
+    window.setTitle_(APP_NAME)
+    window.setMinSize_(AppKit.NSMakeSize(900, 600))
+    window.setReleasedWhenClosed_(False)
+    window.center()
+
+    webview = WebKit.WKWebView.alloc().initWithFrame_(window.contentView().bounds())
+    webview.setAutoresizingMask_(AppKit.NSViewWidthSizable | AppKit.NSViewHeightSizable)
+    page_url = Foundation.NSURL.URLWithString_(target)
+    if page_url is None:
+        raise RuntimeError(f"Invalid StaffDeck window URL: {target!r}")
+    webview.loadRequest_(Foundation.NSURLRequest.requestWithURL_(page_url))
+    window.setContentView_(webview)
+    window.makeKeyAndOrderFront_(None)
+    return window, webview
+
+
 def _run_macos_dock_app(cfg: dict, url: str) -> int:
-    """macOS：NSApplication 主循环。进 Dock/菜单栏，点入口重新打开浏览器。"""
+    """Run the local service behind a native WKWebView window on macOS."""
     import AppKit
+    import Foundation
+    import WebKit
     from PyObjCTools import AppHelper
 
     global _MACOS_DELEGATE_REF
@@ -272,21 +304,25 @@ def _run_macos_dock_app(cfg: dict, url: str) -> int:
         def applicationDidFinishLaunching_(self, _notification):  # noqa: N802
             self.dock_visible = True
             self.server_started = False
+            self.main_window = None
+            self.main_webview = None
             self._install_url_scheme_handler()
             self._install_status_menu()
             self._start_server()
-            print(f"{APP_NAME} 启动中，就绪后将打开：{url}/chat/")
+            print(f"{APP_NAME} 启动中，就绪后将显示应用窗口：{url}/chat/")
 
         def handleGetURLEvent_withReplyEvent_(self, event, _reply_event):  # noqa: N802
             direct_object = event.descriptorForKeyword_(_four_char_code("----"))
             deep_link = direct_object.stringValue() if direct_object is not None else ""
             print(f"收到 {APP_NAME} URL Scheme 唤起：{deep_link or '<empty>'}")
-            threading.Thread(target=_open_browser_when_ready, args=(url,), daemon=True).start()
+            self._show_window_when_ready()
 
         def applicationShouldHandleReopen_hasVisibleWindows_(self, _app, _flag):  # noqa: N802
-            # 点 Dock 图标（app 已在运行）→ 打开浏览器页面（新标签）
-            _open_browser(url + "/chat/")
+            self.showMainWindow_(url + "/chat/")
             return True
+
+        def applicationShouldTerminateAfterLastWindowClosed_(self, _app):
+            return False
 
         def applicationShouldTerminate_(self, _app):  # noqa: N802
             return AppKit.NSTerminateNow
@@ -297,7 +333,19 @@ def _run_macos_dock_app(cfg: dict, url: str) -> int:
             return self.dock_context_menu
 
         def openStaffDeck_(self, _sender):  # noqa: N802
-            _open_browser(url + "/chat/")
+            self.showMainWindow_(url + "/chat/")
+
+        def showMainWindow_(self, target):
+            if self.main_window is None:
+                self.main_window, self.main_webview = _create_macos_webview_window(
+                    AppKit,
+                    Foundation,
+                    WebKit,
+                    str(target),
+                )
+            else:
+                self.main_window.makeKeyAndOrderFront_(None)
+            AppKit.NSApplication.sharedApplication().activateIgnoringOtherApps_(True)
 
         def restartStaffDeck_(self, _sender):  # noqa: N802
             os.execv(sys.executable, [sys.executable] + sys.argv[1:])
@@ -333,7 +381,17 @@ def _run_macos_dock_app(cfg: dict, url: str) -> int:
             # uvicorn 在后台线程跑（主线程要留给 Cocoa 事件循环）。这里必须等
             # NSApplication 完成注册后再启动，避免 LaunchServices 初始化竞态导致 abort。
             threading.Thread(target=_serve, args=(cfg,), daemon=True).start()
-            threading.Thread(target=_open_browser_when_ready, args=(url,), daemon=True).start()
+            self._show_window_when_ready()
+
+        def _show_window_when_ready(self) -> None:
+            def wait_and_show() -> None:
+                for _ in range(120):
+                    if _health_ok(url):
+                        AppHelper.callAfter(self.showMainWindow_, url + "/chat/")
+                        return
+                    time.sleep(0.5)
+
+            threading.Thread(target=wait_and_show, daemon=True).start()
 
         def _install_url_scheme_handler(self) -> None:
             manager = AppKit.NSAppleEventManager.sharedAppleEventManager()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,7 +37,9 @@ dev = [
 ]
 packaging = [
   "pyinstaller>=6.6.0",
-  "certifi>=2024.2.2"
+  "certifi>=2024.2.2",
+  "pyobjc-framework-Cocoa>=10.0; sys_platform == 'darwin'",
+  "pyobjc-framework-WebKit>=10.0; sys_platform == 'darwin'"
 ]
 
 [build-system]

--- a/backend/tests/test_desktop_launcher.py
+++ b/backend/tests/test_desktop_launcher.py
@@ -144,11 +144,122 @@ def test_windows_taskbar_app_disabled_in_headless_mode(monkeypatch) -> None:
     assert desktop_launcher._use_windows_taskbar_app() is False
 
 
+def test_macos_dock_app_disabled_in_headless_mode(monkeypatch) -> None:
+    monkeypatch.setattr(desktop_launcher.sys, "platform", "darwin")
+    monkeypatch.setattr(desktop_launcher.sys, "frozen", True, raising=False)
+    monkeypatch.setenv("STAFFDECK_HEADLESS", "1")
+    assert desktop_launcher._use_macos_dock_app() is False
+
+
 def test_windows_restore_command_detection() -> None:
     assert desktop_launcher._is_windows_restore_command(0x0112, 0xF120) is True
     assert desktop_launcher._is_windows_restore_command(0x0112, 0xF122) is True
     assert desktop_launcher._is_windows_restore_command(0x0112, 0xF020) is False
     assert desktop_launcher._is_windows_restore_command(0x0002, 0xF120) is False
+
+
+def test_macos_window_embeds_local_ui() -> None:
+    events: dict[str, object] = {}
+
+    class FakeContentView:
+        def bounds(self):
+            return (0, 0, 1280, 800)
+
+    class FakeWindow:
+        @classmethod
+        def alloc(cls):
+            return cls()
+
+        def initWithContentRect_styleMask_backing_defer_(self, frame, style, backing, defer):
+            events["window_init"] = (frame, style, backing, defer)
+            return self
+
+        def setTitle_(self, title):
+            events["title"] = title
+
+        def setMinSize_(self, size):
+            events["min_size"] = size
+
+        def setReleasedWhenClosed_(self, released):
+            events["released_when_closed"] = released
+
+        def center(self):
+            events["centered"] = True
+
+        def contentView(self):
+            return FakeContentView()
+
+        def setContentView_(self, view):
+            events["content_view"] = view
+
+        def makeKeyAndOrderFront_(self, sender):
+            events["ordered_front"] = sender
+
+    class FakeWebView:
+        @classmethod
+        def alloc(cls):
+            return cls()
+
+        def initWithFrame_(self, frame):
+            events["webview_frame"] = frame
+            return self
+
+        def setAutoresizingMask_(self, mask):
+            events["autoresizing_mask"] = mask
+
+        def loadRequest_(self, request):
+            events["request"] = request
+
+    class FakeURL:
+        @staticmethod
+        def URLWithString_(target):
+            return f"url:{target}"
+
+    class FakeRequest:
+        @staticmethod
+        def requestWithURL_(url):
+            return f"request:{url}"
+
+    class FakeAppKit:
+        NSWindow = FakeWindow
+        NSWindowStyleMaskTitled = 1
+        NSWindowStyleMaskClosable = 2
+        NSWindowStyleMaskMiniaturizable = 4
+        NSWindowStyleMaskResizable = 8
+        NSBackingStoreBuffered = 2
+        NSViewWidthSizable = 2
+        NSViewHeightSizable = 16
+
+        @staticmethod
+        def NSMakeRect(x, y, width, height):
+            return (x, y, width, height)
+
+        @staticmethod
+        def NSMakeSize(width, height):
+            return (width, height)
+
+    class FakeFoundation:
+        NSURL = FakeURL
+        NSURLRequest = FakeRequest
+
+    class FakeWebKit:
+        WKWebView = FakeWebView
+
+    window, webview = desktop_launcher._create_macos_webview_window(
+        FakeAppKit,
+        FakeFoundation,
+        FakeWebKit,
+        "http://127.0.0.1:5173/chat/",
+    )
+
+    assert isinstance(window, FakeWindow)
+    assert isinstance(webview, FakeWebView)
+    assert webview is events["content_view"]
+    assert events["request"] == "request:url:http://127.0.0.1:5173/chat/"
+    assert events["title"] == "StaffDeck"
+    assert events["min_size"] == (900, 600)
+    assert events["released_when_closed"] is False
+    assert events["centered"] is True
 
 
 def test_frozen_server_disables_api_access_logging(monkeypatch) -> None:

--- a/backend/tests/test_packaging_deps.py
+++ b/backend/tests/test_packaging_deps.py
@@ -15,3 +15,13 @@ def test_pyinstaller_spec_keeps_channel_hiddenimports() -> None:
     content = spec_path.read_text(encoding="utf-8")
     for module in REQUIRED_MODULES:
         assert f'"{module}"' in content, f"packaging/ultrarag.spec 缺少 hiddenimport: {module}"
+
+
+def test_macos_bundle_keeps_webkit_packaging_support() -> None:
+    root = Path(__file__).resolve().parents[2]
+    spec = (root / "packaging" / "ultrarag.spec").read_text(encoding="utf-8")
+    build_script = (root / "packaging" / "build_macos.sh").read_text(encoding="utf-8")
+    pyproject = (root / "backend" / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"WebKit"' in spec
+    assert "pyobjc-framework-WebKit" in build_script
+    assert "pyobjc-framework-WebKit" in pyproject

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,5 @@
+# Domain Docs
+
+Use a single-context documentation layout. Before exploring code, read `CONTEXT.md` at the repository root and relevant decisions under `docs/adr/` when those files exist. If they do not exist, continue silently.
+
+Use terminology defined in `CONTEXT.md`. If work contradicts an ADR, state the conflict explicitly instead of silently overriding the decision.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,3 @@
+# Issue Tracker
+
+This repository does not use an issue tracker for agent workflows. Do not create, update, label, or close issues. Keep implementation work in the current branch and report results directly to the user.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,3 @@
+# Triage Labels
+
+Issue triage labels are not used because agent workflows do not create or manage issues in this repository. The canonical roles `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix` are all not applicable.

--- a/packaging/build_macos.sh
+++ b/packaging/build_macos.sh
@@ -3,10 +3,59 @@ set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO"
 VERSION="${VERSION:-0.1.0}"
-ARCH="$(uname -m)"
+HOST_ARCH="$(uname -m)"
+TARGET_ARCH="${STAFFDECK_MACOS_ARCH:-$HOST_ARCH}"
 MAC_SIGN_ID="${MAC_SIGN_ID:-}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-}"
 NOTARY_KEYCHAIN="${NOTARY_KEYCHAIN:-}"
+
+normalize_arch() {
+  case "$1" in
+    arm64|aarch64) echo "arm64" ;;
+    x86_64|amd64|x64) echo "x86_64" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+HOST_ARCH="$(normalize_arch "$HOST_ARCH")"
+ARCH="$(normalize_arch "$TARGET_ARCH")"
+case "$ARCH" in
+  arm64|x86_64) ;;
+  *)
+    echo "不支持的 macOS 架构: $ARCH（仅支持 arm64 和 x86_64）" >&2
+    exit 1
+    ;;
+esac
+if [ "$ARCH" != "$HOST_ARCH" ]; then
+  echo "目标架构 $ARCH 与 runner 架构 $HOST_ARCH 不一致；请在原生 runner 上构建" >&2
+  exit 1
+fi
+
+verify_bundle_arch() {
+  local app="$1"
+  local checked=0
+  local item
+  local item_arches
+  while IFS= read -r -d '' item; do
+    if ! file -b "$item" | grep -q "Mach-O"; then
+      continue
+    fi
+    item_arches="$(lipo -archs "$item")"
+    case " $item_arches " in
+      *" $ARCH "*) ;;
+      *)
+        echo "架构校验失败: $item 仅包含 [$item_arches]，期望 $ARCH" >&2
+        return 1
+        ;;
+    esac
+    checked=$((checked + 1))
+  done < <(find "$app" -type f -print0)
+  if [ "$checked" -eq 0 ]; then
+    echo "架构校验失败: $app 中未找到 Mach-O 文件" >&2
+    return 1
+  fi
+  echo "✓ 架构校验通过: $checked 个 Mach-O 文件均支持 $ARCH"
+}
 
 sign_code() {
   local target="$1"
@@ -62,6 +111,11 @@ if [ ! -x ".venv/bin/python" ]; then
   python3 -m venv .venv
   .venv/bin/python -m ensurepip --upgrade 2>/dev/null || true
 fi
+PYTHON_ARCH="$(normalize_arch "$(.venv/bin/python -c 'import platform; print(platform.machine())')")"
+if [ "$PYTHON_ARCH" != "$ARCH" ]; then
+  echo "backend/.venv 架构为 $PYTHON_ARCH，但本次目标为 $ARCH；请删除该 venv 后重试" >&2
+  exit 1
+fi
 # 每次打包都重新对齐 pyproject 约束。仅在 pyinstaller 缺失时安装会让旧
 # .venv 绕过 cryptography/OpenSSL 兼容修复，产出不可重现的发布包。
 DEPS="$(.venv/bin/python -c "import tomllib,pathlib; print(' '.join(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['dependencies']))")"
@@ -103,6 +157,7 @@ rm -rf "$APP/Contents/Resources/runtime" "$APP/Contents/MacOS/runtime"
 cp -R packaging/runtime_dl/python "$APP/Contents/Resources/runtime"
 
 echo "==> [5/5] 签名 + 打 dmg"
+verify_bundle_arch "$APP"
 sign_app_bundle "$APP"
 
 if codesign --verify --deep --strict "$APP" 2>/dev/null; then

--- a/packaging/build_macos.sh
+++ b/packaging/build_macos.sh
@@ -131,12 +131,16 @@ else
   echo "无法安装打包依赖：venv 既无 pip 也无 uv" >&2
   exit 1
 fi
-# macOS Dock 壳依赖 pyobjc（幂等，已装则跳过）
-if ! .venv/bin/python -c "import AppKit" >/dev/null 2>&1; then
+# macOS Dock 壳和内嵌 UI 依赖 pyobjc（幂等，已装则跳过）
+if ! .venv/bin/python -c "import AppKit, WebKit" >/dev/null 2>&1; then
   if .venv/bin/python -m pip --version >/dev/null 2>&1; then
-    .venv/bin/python -m pip install "pyobjc-framework-Cocoa>=10.0"
+    .venv/bin/python -m pip install \
+      "pyobjc-framework-Cocoa>=10.0" \
+      "pyobjc-framework-WebKit>=10.0"
   elif command -v uv >/dev/null 2>&1; then
-    VIRTUAL_ENV="$(pwd)/.venv" uv pip install "pyobjc-framework-Cocoa>=10.0"
+    VIRTUAL_ENV="$(pwd)/.venv" uv pip install \
+      "pyobjc-framework-Cocoa>=10.0" \
+      "pyobjc-framework-WebKit>=10.0"
   fi
 fi
 

--- a/packaging/ultrarag.spec
+++ b/packaging/ultrarag.spec
@@ -51,7 +51,7 @@ hiddenimports = (
 # macOS：Dock/菜单栏壳需要 pyobjc（AppKit + PyObjCTools）
 if sys.platform == "darwin":
     hiddenimports = hiddenimports + collect_submodules("objc") + [
-        "AppKit", "Foundation", "PyObjCTools", "PyObjCTools.AppHelper",
+        "AppKit", "Foundation", "WebKit", "PyObjCTools", "PyObjCTools.AppHelper",
     ]
 
 a = Analysis(
@@ -94,6 +94,7 @@ if sys.platform == "darwin":
                 },
             ],
             "NSHighResolutionCapable": True,
+            "NSAppTransportSecurity": {"NSAllowsLocalNetworking": True},
             # 显式声明为常规 GUI app：进 Dock、可激活（非后台/非 agent）
             "LSBackgroundOnly": False,
             "LSUIElement": False,


### PR DESCRIPTION
## 变更背景

  补齐 macOS Intel（x86_64）客户端支持。

  原 macOS 启动器仅常驻 Dock，并通过系统浏览器打开本地页面，导致客户端没有独立可视化窗口。本 PR 改为原生 WKWebView 窗口，并加强 Intel 构建校
  验。

  ## 主要变更

  - GitHub Actions 增加明确的 macOS 架构配置：
    - Apple Silicon：`arm64`
    - Intel：`x86_64`
  - 构建时校验 runner、Python venv 和所有 Mach-O 文件架构。
  - macOS 客户端使用原生 `WKWebView` 展示 StaffDeck UI。
  - 点击 Dock 图标时恢复应用窗口，不再打开 Chrome。
  - 关闭窗口后，本地服务继续常驻。
  - headless 模式不启动 Cocoa/WebView UI。
  - 打包依赖增加 `pyobjc-framework-WebKit`。
  - Info.plist 允许访问本地 HTTP 服务。
  - README 中增加 Intel DMG 下载入口。
  - 增加 macOS 窗口和 WebKit 打包回归测试。
  - 增加仓库 agent 工作流说明。

  ## 验证结果

  - `19 passed`：桌面启动器和打包相关测试。
  - Ruff 测试文件检查通过。
  - 前端 TypeScript/Vite 生产构建通过。
  - Intel Mac 完整打包通过。
  - 156 个 Mach-O 文件全部支持 `x86_64`。
  - 打包应用 `/api/health` 返回正常。
  - 应用启动后 WebKit GPU、WebContent、Networking 进程正常运行。
  - Code signing 密封验证通过。
  - DMG 完整性校验通过。

  ## 产物

  `StaffDeck-macos-x86_64.dmg`

  SHA-256：

  `c49b1fb0389af5ed41a8879204029c8f70b3f2442992640c5461fce4108043d6`

  ## 风险与注意事项

  - 本地验证产物使用 ad-hoc 签名；正式发布仍需 CI 配置 Developer ID 和公证凭据。
  - WKWebView 与 Chrome 的弹窗、下载等行为可能存在差异，建议在 ARM CI/真机上补充一次 UI 验证。