### PR TITLE
feat(channels): add inbound attachment support for feishu and dingtalk

### DIFF
--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -35,6 +35,7 @@ from app.channels.schema import (
     ChannelBindingAgentsUpdate,
     ChannelBindingCreate,
     ChannelBindingRead,
+    ChannelConversationAttachmentRead,
     ChannelConversationMessageRead,
     ChannelConversationPage,
     ChannelConversationRead,
@@ -1331,7 +1332,17 @@ def list_channel_conversation_messages(
             role=row.role,
             content=row.content,
             created_at=row.created_at.isoformat(),
-            attachments=(row.metadata_json or {}).get("attachments"),
+            attachments=[
+                ChannelConversationAttachmentRead(
+                    id=item.get("id"),
+                    filename=item.get("filename"),
+                    content_type=item.get("content_type"),
+                    size=item.get("size"),
+                    kind=item.get("kind"),
+                )
+                for item in ((row.metadata_json or {}).get("attachments") or [])
+            ]
+            or None,
         )
         for row in rows
     ]

--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -1331,6 +1331,7 @@ def list_channel_conversation_messages(
             role=row.role,
             content=row.content,
             created_at=row.created_at.isoformat(),
+            attachments=(row.metadata_json or {}).get("attachments"),
         )
         for row in rows
     ]

--- a/backend/app/channels/adapters/base.py
+++ b/backend/app/channels/adapters/base.py
@@ -3,9 +3,53 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+import httpx
+
 from app.db.models import ChannelBinding
 
 CHANNEL_TEXT_LIMIT = 2000
+
+
+def stream_download_with_limit(
+    client: httpx.Client,
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    params: dict[str, Any] | None = None,
+    json_body: dict[str, Any] | None = None,
+    max_bytes: int = 0,
+) -> tuple[int, bytes]:
+    """流式下载,超限时立即中止。
+
+    返回 (status_code, body_bytes)。
+    max_bytes > 0 时,Content-Length 超限或累计读取超限均抛 ValueError。
+
+    注意: 当 url 自带 query string(如 OSS 签名 URL)时,不要传 params,
+    否则 httpx 会重新编码 URL 导致签名失效。
+    """
+    kwargs: dict[str, Any] = {}
+    if headers:
+        kwargs["headers"] = headers
+    if params:
+        kwargs["params"] = params
+    if json_body is not None:
+        kwargs["json"] = json_body
+    with client.stream(method, url, **kwargs) as response:
+        if response.status_code >= 400:
+            return response.status_code, response.read()
+        if max_bytes > 0:
+            content_length = response.headers.get("content-length")
+            if content_length and int(content_length) > max_bytes:
+                raise ValueError(f"下载内容超过上限 {max_bytes} bytes (Content-Length={content_length})")
+        chunks: list[bytes] = []
+        total = 0
+        for chunk in response.iter_bytes():
+            total += len(chunk)
+            if max_bytes > 0 and total > max_bytes:
+                raise ValueError(f"下载内容超过上限 {max_bytes} bytes (已读取 {total})")
+            chunks.append(chunk)
+        return response.status_code, b"".join(chunks)
 
 
 @dataclass

--- a/backend/app/channels/adapters/base.py
+++ b/backend/app/channels/adapters/base.py
@@ -1,11 +1,27 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 from app.db.models import ChannelBinding
 
 CHANNEL_TEXT_LIMIT = 2000
+
+
+@dataclass
+class ChannelInboundAttachment:
+    """渠道入站附件的内存传递结构(不落库,与 ChannelInbound 同生命周期)。
+
+    各适配器在 normalize 阶段填充,attachment_bridge 通过 download_media
+    获取原始字节后交给 stage_chat_attachment 暂存。
+    """
+
+    media_id: str
+    kind: str  # "image" | "file"
+    filename: str = ""
+    content_type: str = ""
+    size: int = 0
+    download_params: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -27,6 +43,9 @@ class ChannelInbound:
     sender_name: str = ""
     # 渠道账号作用域:wechat 置空;wecom 为 corp_id/bot_id/binding.id(intake 以绑定配置为准重算)
     account_scope: str = ""
+    # 入站附件列表(图片/文件);空列表表示纯文本消息。
+    # 不落库,仅在 intake 调用 attachment_bridge 时使用。
+    attachments: list[ChannelInboundAttachment] = field(default_factory=list)
 
     @property
     def conv_key(self) -> str:

--- a/backend/app/channels/adapters/dingtalk.py
+++ b/backend/app/channels/adapters/dingtalk.py
@@ -21,6 +21,7 @@ from app.channels.adapters.base import (
     ChannelInboundAttachment,
     register_channel_adapter,
     split_channel_text,
+    stream_download_with_limit,
 )
 from app.channels.crypto import decrypt_channel_secret
 from app.db import engine
@@ -136,6 +137,23 @@ def _text_value(raw: dict[str, Any]) -> str:
     return str(value or "").strip()
 
 
+def _richtext_text(raw: dict[str, Any]) -> str:
+    """从 richtext 消息的 content.richText 数组中拼接文本。"""
+    content = raw.get("content") or {}
+    if not isinstance(content, dict):
+        return ""
+    rich_text = content.get("richText") or content.get("rich_text") or []
+    if not isinstance(rich_text, list):
+        return ""
+    parts: list[str] = []
+    for item in rich_text:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("type") or "").strip().lower() == "text":
+            parts.append(str(item.get("text") or ""))
+    return "".join(parts).strip()
+
+
 def _strip_bot_mention(text: str, raw: dict[str, Any], *, is_group: bool) -> str:
     """DingTalk may include the @ token in text.content as well as atUsers."""
     if not is_group or raw.get("isInAtList") is not True:
@@ -154,6 +172,7 @@ def _extract_dingtalk_attachments(
     钉钉 stream SDK 把图片/文件正文放在 raw.content 下:
     - picture: raw.content.downloadCode + raw.content.pictureDownloadCode
     - file: raw.content.downloadCode + raw.content.fileName
+    - richtext: raw.content.richText 数组,遍历 type=="picture" 的条目取 downloadCode
     robotCode 在 download_media 时由适配器从 binding 配置解析(= client_id)。
     """
     attachments: list[ChannelInboundAttachment] = []
@@ -167,8 +186,8 @@ def _extract_dingtalk_attachments(
                 ChannelInboundAttachment(
                     media_id=download_code,
                     kind="image",
-                    filename=f"{download_code[:12]}.jpg",
-                    content_type="image/jpeg",
+                    filename=download_code[:12],
+                    content_type="",
                     download_params={"download_code": download_code, "type": "picture"},
                 )
             )
@@ -185,6 +204,25 @@ def _extract_dingtalk_attachments(
                     download_params={"download_code": download_code, "type": "file"},
                 )
             )
+    elif msgtype in {"richtext", "rich_text"}:
+        rich_text = content.get("richText") or content.get("rich_text") or []
+        if isinstance(rich_text, list):
+            for item in rich_text:
+                if not isinstance(item, dict):
+                    continue
+                if str(item.get("type") or "").strip().lower() != "picture":
+                    continue
+                download_code = str(item.get("downloadCode") or "").strip()
+                if download_code:
+                    attachments.append(
+                        ChannelInboundAttachment(
+                            media_id=download_code,
+                            kind="image",
+                            filename=download_code[:12],
+                            content_type="",
+                            download_params={"download_code": download_code, "type": "picture"},
+                        )
+                    )
     return attachments
 
 
@@ -193,8 +231,8 @@ def normalize_dingtalk_message(raw: dict[str, Any], *, account_scope: str = "") 
     if not isinstance(raw, dict):
         return None
     msgtype = str(raw.get("msgtype") or "").strip().lower()
-    # 放宽 msgtype 过滤:允许 text / picture / file
-    if msgtype not in {"text", "picture", "file"}:
+    # 放宽 msgtype 过滤:允许 text / picture / file / richtext
+    if msgtype not in {"text", "picture", "file", "richtext", "rich_text"}:
         return None
     sender_id = str(raw.get("senderStaffId") or "").strip()
     if not sender_id:
@@ -209,10 +247,12 @@ def normalize_dingtalk_message(raw: dict[str, Any], *, account_scope: str = "") 
     # 提取图片/文件附件(picture/file 消息)
     attachments = _extract_dingtalk_attachments(raw, msgtype)
 
-    # 文本只在 text 类型时提取
+    # 文本在 text 类型时从 raw.text 提取,richtext 类型时从 content.richText 数组提取
     text = ""
     if msgtype == "text":
         text = _text_value(raw)
+    elif msgtype in {"richtext", "rich_text"}:
+        text = _richtext_text(raw)
     if not text and not attachments:
         return None
 
@@ -411,15 +451,18 @@ class DingTalkAdapter:
         self,
         binding: ChannelBinding,
         attachment: ChannelInboundAttachment,
+        *,
+        max_bytes: int = 0,
     ) -> bytes:
         """钉钉附件下载:先获取下载 URL,再下载文件内容。
 
-        第一步: POST /robot/messageCenter/file/download
+        第一步: POST /robot/messageFiles/download
             body = {"downloadCode": "...", "robotCode": "<client_id>"}
             返回 {"downloadUrl": "..."}
         第二步: GET downloadUrl, 超时 15s。
         robotCode 取 binding 配置的 client_id(_credential 第一个返回值)。
         复用 DingTalkTokenProvider 的 token 刷新重试模式(401 -> invalidate -> 重试一次)。
+        max_bytes > 0 时第二步流式读取,超过上限立即中止。
         """
         download_code = str(
             attachment.download_params.get("download_code") or attachment.media_id
@@ -466,9 +509,20 @@ class DingTalkAdapter:
             raise DingTalkPermanentError("钉钉 token 刷新后仍无法下载附件")
 
         # 第二步:从 downloadUrl 下载实际文件
+        # downloadUrl 自带签名 query string,不传 params 避免 httpx 重新编码 URL 导致签名失效
         try:
             with self._client_factory() as client:
+                if max_bytes > 0:
+                    status, data = stream_download_with_limit(
+                        client, "GET", download_url,
+                        max_bytes=max_bytes,
+                    )
+                    if status != 200:
+                        raise DingTalkTransientError(f"钉钉附件下载失败 HTTP {status}")
+                    return data
                 response = client.get(download_url, timeout=15.0)
+        except ValueError:
+            raise
         except (httpx.TimeoutException, httpx.NetworkError) as exc:
             raise DingTalkTransientError("钉钉附件下载暂时失败") from exc
         if response.status_code != 200:

--- a/backend/app/channels/adapters/dingtalk.py
+++ b/backend/app/channels/adapters/dingtalk.py
@@ -16,7 +16,12 @@ import httpx
 from sqlmodel import Session, select
 from sqlalchemy import update
 
-from app.channels.adapters.base import ChannelInbound, register_channel_adapter, split_channel_text
+from app.channels.adapters.base import (
+    ChannelInbound,
+    ChannelInboundAttachment,
+    register_channel_adapter,
+    split_channel_text,
+)
 from app.channels.crypto import decrypt_channel_secret
 from app.db import engine
 from app.db.models import ChannelBinding
@@ -140,11 +145,56 @@ def _strip_bot_mention(text: str, raw: dict[str, Any], *, is_group: bool) -> str
     return re.sub(r"^\s*@[^\s]+\s*", "", text, count=1).strip()
 
 
+def _extract_dingtalk_attachments(
+    raw: dict[str, Any],
+    msgtype: str,
+) -> list[ChannelInboundAttachment]:
+    """从钉钉消息提取图片/文件附件。
+
+    钉钉 stream SDK 把图片/文件正文放在 raw.content 下:
+    - picture: raw.content.downloadCode + raw.content.pictureDownloadCode
+    - file: raw.content.downloadCode + raw.content.fileName
+    robotCode 在 download_media 时由适配器从 binding 配置解析(= client_id)。
+    """
+    attachments: list[ChannelInboundAttachment] = []
+    content = raw.get("content") or {}
+    if not isinstance(content, dict):
+        content = {}
+    if msgtype == "picture":
+        download_code = str(content.get("downloadCode") or "").strip()
+        if download_code:
+            attachments.append(
+                ChannelInboundAttachment(
+                    media_id=download_code,
+                    kind="image",
+                    filename=f"{download_code[:12]}.jpg",
+                    content_type="image/jpeg",
+                    download_params={"download_code": download_code, "type": "picture"},
+                )
+            )
+    elif msgtype == "file":
+        download_code = str(content.get("downloadCode") or "").strip()
+        file_name = str(content.get("fileName") or "").strip()
+        if download_code:
+            attachments.append(
+                ChannelInboundAttachment(
+                    media_id=download_code,
+                    kind="file",
+                    filename=file_name or download_code[:12],
+                    content_type="",
+                    download_params={"download_code": download_code, "type": "file"},
+                )
+            )
+    return attachments
+
+
 def normalize_dingtalk_message(raw: dict[str, Any], *, account_scope: str = "") -> ChannelInbound | None:
     """Normalize a DingTalk Stream chatbot callback payload."""
     if not isinstance(raw, dict):
         return None
-    if str(raw.get("msgtype") or "") != "text":
+    msgtype = str(raw.get("msgtype") or "").strip().lower()
+    # 放宽 msgtype 过滤:允许 text / picture / file
+    if msgtype not in {"text", "picture", "file"}:
         return None
     sender_id = str(raw.get("senderStaffId") or "").strip()
     if not sender_id:
@@ -153,15 +203,26 @@ def normalize_dingtalk_message(raw: dict[str, Any], *, account_scope: str = "") 
         return None
     message_id = str(raw.get("msgId") or "").strip()
     conversation_id = str(raw.get("conversationId") or "").strip()
-    text = _text_value(raw)
-    if not message_id or not conversation_id or not text:
+    if not message_id or not conversation_id:
         return None
+
+    # 提取图片/文件附件(picture/file 消息)
+    attachments = _extract_dingtalk_attachments(raw, msgtype)
+
+    # 文本只在 text 类型时提取
+    text = ""
+    if msgtype == "text":
+        text = _text_value(raw)
+    if not text and not attachments:
+        return None
+
     is_group = str(raw.get("conversationType") or "") == "2"
     if is_group and raw.get("isInAtList") is not True:
         return None
-    text = _strip_bot_mention(text, raw, is_group=is_group)
-    if not text:
-        return None
+    if text:
+        text = _strip_bot_mention(text, raw, is_group=is_group)
+        if not text and not attachments:
+            return None
     context_token = str(raw.get("sessionWebhook") or "").strip()
     if not context_token:
         return None
@@ -178,6 +239,7 @@ def normalize_dingtalk_message(raw: dict[str, Any], *, account_scope: str = "") 
         raw=raw,
         sender_name=str(raw.get("senderNick") or "").strip(),
         account_scope=account_scope.strip(),
+        attachments=attachments,
     )
 
 
@@ -344,6 +406,74 @@ class DingTalkAdapter:
             target,
             str(target.get("reaction_token") or "") or DINGTALK_ACK_EMOTION_NAME,
         )
+
+    def download_media(
+        self,
+        binding: ChannelBinding,
+        attachment: ChannelInboundAttachment,
+    ) -> bytes:
+        """钉钉附件下载:先获取下载 URL,再下载文件内容。
+
+        第一步: POST /robot/messageCenter/file/download
+            body = {"downloadCode": "...", "robotCode": "<client_id>"}
+            返回 {"downloadUrl": "..."}
+        第二步: GET downloadUrl, 超时 15s。
+        robotCode 取 binding 配置的 client_id(_credential 第一个返回值)。
+        复用 DingTalkTokenProvider 的 token 刷新重试模式(401 -> invalidate -> 重试一次)。
+        """
+        download_code = str(
+            attachment.download_params.get("download_code") or attachment.media_id
+        )
+        if not download_code:
+            raise DingTalkPermanentError("钉钉附件下载缺少 downloadCode")
+        robot_code, _ = _credential(binding)  # robotCode = client_id
+
+        # 第一步:获取下载 URL
+        url = f"{DINGTALK_API_BASE}/robot/messageFiles/download"
+        force_refresh = False
+        download_url: str = ""
+        for attempt in range(2):
+            token = self._tokens.get(binding, force_refresh=force_refresh)
+            force_refresh = False
+            try:
+                with self._client_factory() as client:
+                    response = client.post(
+                        url,
+                        json={"downloadCode": download_code, "robotCode": robot_code},
+                        headers={
+                            "x-acs-dingtalk-access-token": token,
+                            "Content-Type": "application/json",
+                        },
+                    )
+            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                raise DingTalkTransientError("钉钉附件下载暂时失败") from exc
+            if response.status_code == 401 and attempt == 0:
+                force_refresh = self._tokens.invalidate(binding, expected_token=token)
+                continue
+            if response.status_code == 429 or response.status_code >= 500:
+                raise DingTalkTransientError("钉钉附件下载服务暂时不可用")
+            if response.status_code >= 400:
+                raise DingTalkPermanentError(f"钉钉拒绝附件下载 HTTP {response.status_code}")
+            try:
+                data = response.json()
+            except ValueError as exc:
+                raise DingTalkTransientError("钉钉附件下载响应格式无效") from exc
+            download_url = str(data.get("downloadUrl") or "").strip()
+            if not download_url:
+                raise DingTalkPermanentError("钉钉附件下载响应缺少 downloadUrl")
+            break
+        else:
+            raise DingTalkPermanentError("钉钉 token 刷新后仍无法下载附件")
+
+        # 第二步:从 downloadUrl 下载实际文件
+        try:
+            with self._client_factory() as client:
+                response = client.get(download_url, timeout=15.0)
+        except (httpx.TimeoutException, httpx.NetworkError) as exc:
+            raise DingTalkTransientError("钉钉附件下载暂时失败") from exc
+        if response.status_code != 200:
+            raise DingTalkTransientError(f"钉钉附件下载失败 HTTP {response.status_code}")
+        return response.content
 
     def send(
         self,

--- a/backend/app/channels/adapters/feishu.py
+++ b/backend/app/channels/adapters/feishu.py
@@ -12,6 +12,7 @@ from app.channels.adapters.base import (
     ChannelInboundAttachment,
     register_channel_adapter,
     split_channel_text,
+    stream_download_with_limit,
 )
 from app.channels.crypto import decrypt_channel_secret
 from app.db.models import ChannelBinding
@@ -328,12 +329,15 @@ class FeishuAdapter:
         self,
         binding: ChannelBinding,
         attachment: ChannelInboundAttachment,
+        *,
+        max_bytes: int = 0,
     ) -> bytes:
         """飞书附件下载:im/v1/messages/{message_id}/resources/{file_key}?type=image|file。
 
         download_params 中需含 file_key / type / message_id。
         下载返回二进制流,不走 _request(那个解析 JSON),直接使用 response.content。
         复用 FeishuTokenProvider 的 token 刷新重试模式(401 -> invalidate -> 重试一次)。
+        max_bytes > 0 时流式读取,超过上限立即中止并抛 ValueError。
         """
         file_key = str(attachment.download_params.get("file_key") or attachment.media_id)
         media_type = str(attachment.download_params.get("type") or "").strip()
@@ -349,11 +353,28 @@ class FeishuAdapter:
             force_refresh = False
             try:
                 with self._client_factory() as client:
+                    if max_bytes > 0:
+                        status, data = stream_download_with_limit(
+                            client, "GET", url,
+                            params={"type": media_type},
+                            headers={"Authorization": f"Bearer {token}"},
+                            max_bytes=max_bytes,
+                        )
+                        if status == 401 and attempt == 0:
+                            force_refresh = self._tokens.invalidate(binding, expected_token=token)
+                            continue
+                        if status == 429 or status >= 500:
+                            raise FeishuTransientError("飞书附件下载服务暂时不可用")
+                        if status >= 400:
+                            raise FeishuPermanentError(f"飞书拒绝附件下载 HTTP {status}")
+                        return data
                     response = client.get(
                         url,
                         params={"type": media_type},
                         headers={"Authorization": f"Bearer {token}"},
                     )
+            except ValueError:
+                raise
             except (httpx.TimeoutException, httpx.NetworkError) as exc:
                 raise FeishuTransientError("飞书附件下载暂时失败") from exc
             if response.status_code == 401 and attempt == 0:

--- a/backend/app/channels/adapters/feishu.py
+++ b/backend/app/channels/adapters/feishu.py
@@ -8,7 +8,11 @@ from typing import Any, Callable
 
 import httpx
 
-from app.channels.adapters.base import register_channel_adapter, split_channel_text
+from app.channels.adapters.base import (
+    ChannelInboundAttachment,
+    register_channel_adapter,
+    split_channel_text,
+)
 from app.channels.crypto import decrypt_channel_secret
 from app.db.models import ChannelBinding
 
@@ -308,7 +312,7 @@ class FeishuAdapter:
         target: dict[str, Any],
         reaction_id: str,
     ) -> None:
-        message_id = str((target or {}).get("message_id") or "").strip()
+        message_id = str(target.get("message_id") or "").strip()
         reaction_id = str(reaction_id or "").strip()
         if not message_id or not reaction_id:
             raise FeishuPermanentError("飞书 reaction 清理参数无效")
@@ -319,6 +323,48 @@ class FeishuAdapter:
             params=None,
             body=None,
         )
+
+    def download_media(
+        self,
+        binding: ChannelBinding,
+        attachment: ChannelInboundAttachment,
+    ) -> bytes:
+        """飞书附件下载:im/v1/messages/{message_id}/resources/{file_key}?type=image|file。
+
+        download_params 中需含 file_key / type / message_id。
+        下载返回二进制流,不走 _request(那个解析 JSON),直接使用 response.content。
+        复用 FeishuTokenProvider 的 token 刷新重试模式(401 -> invalidate -> 重试一次)。
+        """
+        file_key = str(attachment.download_params.get("file_key") or attachment.media_id)
+        media_type = str(attachment.download_params.get("type") or "").strip()
+        message_id = str(attachment.download_params.get("message_id") or "").strip()
+        if not file_key or not media_type or not message_id:
+            raise FeishuPermanentError(
+                f"飞书附件下载参数缺失: file_key={file_key} type={media_type} message_id={message_id}"
+            )
+        url = f"{FEISHU_API_BASE}/im/v1/messages/{message_id}/resources/{file_key}"
+        force_refresh = False
+        for attempt in range(2):
+            token = self._tokens.get(binding, force_refresh=force_refresh)
+            force_refresh = False
+            try:
+                with self._client_factory() as client:
+                    response = client.get(
+                        url,
+                        params={"type": media_type},
+                        headers={"Authorization": f"Bearer {token}"},
+                    )
+            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                raise FeishuTransientError("飞书附件下载暂时失败") from exc
+            if response.status_code == 401 and attempt == 0:
+                force_refresh = self._tokens.invalidate(binding, expected_token=token)
+                continue
+            if response.status_code == 429 or response.status_code >= 500:
+                raise FeishuTransientError("飞书附件下载服务暂时不可用")
+            if response.status_code >= 400:
+                raise FeishuPermanentError(f"飞书拒绝附件下载 HTTP {response.status_code}")
+            return response.content
+        raise FeishuPermanentError("飞书 token 刷新后仍无法下载附件")
 
     def send(
         self,

--- a/backend/app/channels/attachment_bridge.py
+++ b/backend/app/channels/attachment_bridge.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.channels.adapters.base import ChannelInbound
+from app.db.models import ChannelBinding
+from app.session.session_schema import ChatAttachmentRead
+
+logger = logging.getLogger(__name__)
+
+MAX_CHANNEL_MEDIA_BYTES = 25 * 1024 * 1024  # 25MB
+
+
+def inbound_attachments_to_chat(
+    binding: ChannelBinding,
+    inbound: ChannelInbound,
+    *,
+    db_engine: Any,
+    tenant_id: str,
+    user_id: str,
+) -> list[ChatAttachmentRead]:
+    """下载渠道附件,暂存原始字节,转为 ChatAttachmentRead 列表。
+
+    调用各适配器的 download_media 方法获取原始字节,然后复用 web chat 的
+    parse_chat_attachment + stage_chat_attachment 完成解析和暂存。
+
+    单个附件失败不影响其他附件和主链路(intake 侧再降级为纯文本轮)。
+    """
+    # 延迟 import 避免 app.core -> app.session.attachment_store 的循环依赖
+    from app.channels.adapters.base import get_channel_adapter
+
+    adapter = get_channel_adapter(inbound.channel)
+    download_media = getattr(adapter, "download_media", None)
+    if download_media is None:
+        logger.warning("渠道 %s 未实现 download_media,跳过附件", inbound.channel)
+        return []
+
+    # 真正需要下载/暂存时才 import,避免循环依赖与无谓加载
+    from app.session.attachment_store import stage_chat_attachment
+    from app.session.attachments import parse_chat_attachment
+
+    results: list[ChatAttachmentRead] = []
+    for att in inbound.attachments:
+        try:
+            data = download_media(binding, att)
+            if not data:
+                continue
+            if len(data) > MAX_CHANNEL_MEDIA_BYTES:
+                logger.warning(
+                    "渠道附件超过大小上限 binding=%s media_id=%s size=%d",
+                    binding.id,
+                    att.media_id,
+                    len(data),
+                )
+                continue
+            content_type = att.content_type or None
+            attachment = parse_chat_attachment(
+                att.filename or att.media_id,
+                content_type,
+                data,
+            )
+            staged = stage_chat_attachment(
+                attachment,
+                data,
+                tenant_id=tenant_id,
+                user_id=user_id,
+            )
+            results.append(staged)
+        except Exception:
+            logger.exception(
+                "渠道附件处理失败 binding=%s media_id=%s",
+                binding.id,
+                att.media_id,
+            )
+    return results

--- a/backend/app/channels/attachment_bridge.py
+++ b/backend/app/channels/attachment_bridge.py
@@ -11,6 +11,50 @@ logger = logging.getLogger(__name__)
 
 MAX_CHANNEL_MEDIA_BYTES = 25 * 1024 * 1024  # 25MB
 
+# 图片 magic bytes 签名 → (content_type, extension)
+_IMAGE_SIGNATURES: list[tuple[bytes, str, str]] = [
+    (b"\x89PNG\r\n\x1a\n", "image/png", ".png"),
+    (b"\xff\xd8\xff", "image/jpeg", ".jpg"),
+    (b"GIF87a", "image/gif", ".gif"),
+    (b"GIF89a", "image/gif", ".gif"),
+    (b"RIFF", "image/webp", ".webp"),  # 需后续确认 WebP 标记
+    (b"BM", "image/bmp", ".bmp"),
+]
+
+
+def _detect_image_type(data: bytes) -> tuple[str, str] | None:
+    """从字节签名推断图片 content_type 和扩展名。返回 (content_type, ext) 或 None。"""
+    if len(data) < 12:
+        return None
+    for sig, content_type, ext in _IMAGE_SIGNATURES:
+        if data.startswith(sig):
+            if sig == b"RIFF" and data[8:12] != b"WEBP":
+                continue
+            return content_type, ext
+    return None
+
+
+def _resolve_content_type(
+    att_content_type: str,
+    att_filename: str,
+    data: bytes,
+) -> tuple[str, str]:
+    """根据下载字节修正 content_type 和 filename。
+
+    渠道 normalize 阶段可能无法确定真实 MIME(飞书 image_key 不含扩展名,
+    钉钉 picture 消息也不提供类型),因此下载后用 magic bytes 覆盖。
+    """
+    detected = _detect_image_type(data)
+    if detected:
+        content_type, ext = detected
+        filename = att_filename
+        if not filename.lower().endswith(ext):
+            filename = f"{att_filename}{ext}"
+        return content_type, filename
+    # 非图片或无法识别:保留渠道侧提供的值,空则传 None 让 parse 自动推断
+    ct = (att_content_type or "").strip()
+    return (ct or None, att_filename)  # type: ignore[return-value]
+
 
 def inbound_attachments_to_chat(
     binding: ChannelBinding,
@@ -43,20 +87,16 @@ def inbound_attachments_to_chat(
     results: list[ChatAttachmentRead] = []
     for att in inbound.attachments:
         try:
-            data = download_media(binding, att)
+            data = download_media(binding, att, max_bytes=MAX_CHANNEL_MEDIA_BYTES)
             if not data:
                 continue
-            if len(data) > MAX_CHANNEL_MEDIA_BYTES:
-                logger.warning(
-                    "渠道附件超过大小上限 binding=%s media_id=%s size=%d",
-                    binding.id,
-                    att.media_id,
-                    len(data),
-                )
-                continue
-            content_type = att.content_type or None
-            attachment = parse_chat_attachment(
+            content_type, filename = _resolve_content_type(
+                att.content_type,
                 att.filename or att.media_id,
+                data,
+            )
+            attachment = parse_chat_attachment(
+                filename,
                 content_type,
                 data,
             )

--- a/backend/app/channels/feishu_runtime.py
+++ b/backend/app/channels/feishu_runtime.py
@@ -27,6 +27,15 @@ def _text_content(message) -> str:
     return str(parsed.get("text") or "").strip() if isinstance(parsed, dict) else ""
 
 
+def _post_text_content(message) -> str:
+    """从 post(富文本)消息中提取纯文本,拼接所有 tag=="text" 节点的 text 字段。"""
+    parts: list[str] = []
+    for node in _parse_post_content(message):
+        if str(node.get("tag") or "").strip().lower() == "text":
+            parts.append(str(node.get("text") or ""))
+    return " ".join(part for part in (s.strip() for s in parts) if part)
+
+
 def _image_file_content(message) -> dict[str, str]:
     """从 message.content JSON 中提取 image_key/file_key。
 
@@ -42,51 +51,111 @@ def _image_file_content(message) -> dict[str, str]:
     return parsed
 
 
+def _parse_post_content(message) -> list[dict]:
+    """解析 post(富文本)消息的 content,返回扁平化的内容节点列表。
+
+    飞书 post 消息 content 标准结构形如:
+    {"zh_cn": {"title": "...", "content": [[{"tag": "img", ...}, ...]]}}
+    但部分客户端(如群聊图片+@)会发送不带 locale 包裹的结构:
+    {"title": "...", "content": [[...]], "content_v2": [[...]]}
+    本函数同时兼容两种结构,优先查找 locale 包裹,找不到则在顶层查找 content。
+    """
+    try:
+        parsed = json.loads(str(message.content or "{}"))
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(parsed, dict):
+        return []
+    locale_block = None
+    for key in ("zh_cn", "en_us", "ja_jp", "ko_kr"):
+        block = parsed.get(key)
+        if isinstance(block, dict):
+            locale_block = block
+            break
+    content_rows = None
+    if locale_block is not None:
+        content_rows = locale_block.get("content")
+    elif "content" in parsed:
+        content_rows = parsed.get("content")
+    if not isinstance(content_rows, list):
+        return []
+    nodes: list[dict] = []
+    for row in content_rows:
+        if not isinstance(row, list):
+            continue
+        for node in row:
+            if isinstance(node, dict):
+                nodes.append(node)
+    return nodes
+
+
 def _extract_feishu_attachments(message) -> list[ChannelInboundAttachment]:
     """从飞书 message 提取图片/文件附件。
 
     image 消息使用 image_key,file 消息使用 file_key + file_name。
+    post(富文本)消息从 content 二维数组中提取 tag=="img" 的 image_key。
     message_id 写入 download_params,供 download_media 拼接资源下载 URL。
     """
     message_type = str(message.message_type or "").strip().lower()
-    content = _image_file_content(message)
-    if not content:
-        return []
     message_id = str(message.message_id or "").strip()
     attachments: list[ChannelInboundAttachment] = []
-    if message_type == "image":
-        image_key = str(content.get("image_key") or "").strip()
-        if image_key:
-            attachments.append(
-                ChannelInboundAttachment(
-                    media_id=image_key,
-                    kind="image",
-                    filename=image_key,
-                    content_type="",
-                    download_params={
-                        "file_key": image_key,
-                        "type": "image",
-                        "message_id": message_id,
-                    },
+
+    if message_type in {"image", "file"}:
+        content = _image_file_content(message)
+        if not content:
+            return []
+        if message_type == "image":
+            image_key = str(content.get("image_key") or "").strip()
+            if image_key:
+                attachments.append(
+                    ChannelInboundAttachment(
+                        media_id=image_key,
+                        kind="image",
+                        filename=image_key,
+                        content_type="",
+                        download_params={
+                            "file_key": image_key,
+                            "type": "image",
+                            "message_id": message_id,
+                        },
+                    )
                 )
-            )
-    elif message_type == "file":
-        file_key = str(content.get("file_key") or "").strip()
-        file_name = str(content.get("file_name") or "").strip()
-        if file_key:
-            attachments.append(
-                ChannelInboundAttachment(
-                    media_id=file_key,
-                    kind="file",
-                    filename=file_name or file_key,
-                    content_type="",
-                    download_params={
-                        "file_key": file_key,
-                        "type": "file",
-                        "message_id": message_id,
-                    },
+        else:
+            file_key = str(content.get("file_key") or "").strip()
+            file_name = str(content.get("file_name") or "").strip()
+            if file_key:
+                attachments.append(
+                    ChannelInboundAttachment(
+                        media_id=file_key,
+                        kind="file",
+                        filename=file_name or file_key,
+                        content_type="",
+                        download_params={
+                            "file_key": file_key,
+                            "type": "file",
+                            "message_id": message_id,
+                        },
+                    )
                 )
-            )
+    elif message_type == "post":
+        for node in _parse_post_content(message):
+            tag = str(node.get("tag") or "").strip().lower()
+            if tag == "img":
+                image_key = str(node.get("image_key") or "").strip()
+                if image_key:
+                    attachments.append(
+                        ChannelInboundAttachment(
+                            media_id=image_key,
+                            kind="image",
+                            filename=image_key,
+                            content_type="",
+                            download_params={
+                                "file_key": image_key,
+                                "type": "image",
+                                "message_id": message_id,
+                            },
+                        )
+                    )
     return attachments
 
 
@@ -106,9 +175,9 @@ def _normalize_event(event, *, bot_open_id: str) -> tuple[ChannelInbound, dict] 
     chat_id = str(message.chat_id or "").strip()
     chat_type = str(message.chat_type or "").strip().lower()
     message_type = str(message.message_type or "").strip().lower()
-    # 放宽 message_type 过滤:允许 text / image / file
+    # 放宽 message_type 过滤:允许 text / image / file / post
     if (
-        message_type not in {"text", "image", "file"}
+        message_type not in {"text", "image", "file", "post"}
         or not app_id
         or not tenant_key
         or not message_id
@@ -121,10 +190,12 @@ def _normalize_event(event, *, bot_open_id: str) -> tuple[ChannelInbound, dict] 
     # 提取图片/文件附件(image/file 消息)
     attachments = _extract_feishu_attachments(message)
 
-    # 文本只在 text 类型时提取
+    # 文本在 text / post 类型时提取
     text = ""
     if message_type == "text":
         text = _text_content(message)
+    elif message_type == "post":
+        text = _post_text_content(message)
     if not text and not attachments:
         return None
 

--- a/backend/app/channels/feishu_runtime.py
+++ b/backend/app/channels/feishu_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import json
+import logging
 from pathlib import Path
 
 from sqlalchemy.pool import NullPool
@@ -13,6 +14,9 @@ from app.channels.crypto import decrypt_channel_secret
 from app.channels.service_feishu_inbox import StageDisposition, stage_feishu_inbound
 from app.db.models import ChannelBinding
 from feishu_connector_worker import SDK_CONTRACT_VERSION
+
+
+logger = logging.getLogger(__name__)
 
 
 def _text_content(message) -> str:
@@ -57,8 +61,8 @@ def _extract_feishu_attachments(message) -> list[ChannelInboundAttachment]:
                 ChannelInboundAttachment(
                     media_id=image_key,
                     kind="image",
-                    filename=f"{image_key}.jpg",
-                    content_type="image/jpeg",
+                    filename=image_key,
+                    content_type="",
                     download_params={
                         "file_key": image_key,
                         "type": "image",
@@ -135,7 +139,7 @@ def _normalize_event(event, *, bot_open_id: str) -> tuple[ChannelInbound, dict] 
             if str(getattr(getattr(mention, "id", None), "open_id", "") or "")
             == bot_open_id
         ]
-        if not bot_mentions:
+        if not bot_mentions and not attachments:
             return None
         for mention in bot_mentions:
             key = str(getattr(mention, "key", "") or "")

--- a/backend/app/channels/feishu_runtime.py
+++ b/backend/app/channels/feishu_runtime.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from sqlalchemy.pool import NullPool
 from sqlmodel import Session, create_engine
 
-from app.channels.adapters.base import ChannelInbound
+from app.channels.adapters.base import ChannelInbound, ChannelInboundAttachment
 from app.channels.crypto import decrypt_channel_secret
 from app.channels.service_feishu_inbox import StageDisposition, stage_feishu_inbound
 from app.db.models import ChannelBinding
@@ -21,6 +21,69 @@ def _text_content(message) -> str:
     except (TypeError, ValueError):
         return ""
     return str(parsed.get("text") or "").strip() if isinstance(parsed, dict) else ""
+
+
+def _image_file_content(message) -> dict[str, str]:
+    """从 message.content JSON 中提取 image_key/file_key。
+
+    飞书 image 消息 content 形如: {"image_key": "img_v3_xxxx"}
+    飞书 file 消息 content 形如: {"file_key": "file_v3_xxxx", "file_name": "xxx.pdf"}
+    """
+    try:
+        parsed = json.loads(str(message.content or "{}"))
+    except (TypeError, ValueError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return parsed
+
+
+def _extract_feishu_attachments(message) -> list[ChannelInboundAttachment]:
+    """从飞书 message 提取图片/文件附件。
+
+    image 消息使用 image_key,file 消息使用 file_key + file_name。
+    message_id 写入 download_params,供 download_media 拼接资源下载 URL。
+    """
+    message_type = str(message.message_type or "").strip().lower()
+    content = _image_file_content(message)
+    if not content:
+        return []
+    message_id = str(message.message_id or "").strip()
+    attachments: list[ChannelInboundAttachment] = []
+    if message_type == "image":
+        image_key = str(content.get("image_key") or "").strip()
+        if image_key:
+            attachments.append(
+                ChannelInboundAttachment(
+                    media_id=image_key,
+                    kind="image",
+                    filename=f"{image_key}.jpg",
+                    content_type="image/jpeg",
+                    download_params={
+                        "file_key": image_key,
+                        "type": "image",
+                        "message_id": message_id,
+                    },
+                )
+            )
+    elif message_type == "file":
+        file_key = str(content.get("file_key") or "").strip()
+        file_name = str(content.get("file_name") or "").strip()
+        if file_key:
+            attachments.append(
+                ChannelInboundAttachment(
+                    media_id=file_key,
+                    kind="file",
+                    filename=file_name or file_key,
+                    content_type="",
+                    download_params={
+                        "file_key": file_key,
+                        "type": "file",
+                        "message_id": message_id,
+                    },
+                )
+            )
+    return attachments
 
 
 def _normalize_event(event, *, bot_open_id: str) -> tuple[ChannelInbound, dict] | None:
@@ -38,8 +101,10 @@ def _normalize_event(event, *, bot_open_id: str) -> tuple[ChannelInbound, dict] 
     sender_type = str(sender.sender_type or "").strip().lower()
     chat_id = str(message.chat_id or "").strip()
     chat_type = str(message.chat_type or "").strip().lower()
+    message_type = str(message.message_type or "").strip().lower()
+    # 放宽 message_type 过滤:允许 text / image / file
     if (
-        str(message.message_type or "").strip().lower() != "text"
+        message_type not in {"text", "image", "file"}
         or not app_id
         or not tenant_key
         or not message_id
@@ -48,8 +113,15 @@ def _normalize_event(event, *, bot_open_id: str) -> tuple[ChannelInbound, dict] 
         or open_id == bot_open_id
     ):
         return None
-    text = _text_content(message)
-    if not text:
+
+    # 提取图片/文件附件(image/file 消息)
+    attachments = _extract_feishu_attachments(message)
+
+    # 文本只在 text 类型时提取
+    text = ""
+    if message_type == "text":
+        text = _text_content(message)
+    if not text and not attachments:
         return None
 
     is_group = chat_type != "p2p"
@@ -70,7 +142,7 @@ def _normalize_event(event, *, bot_open_id: str) -> tuple[ChannelInbound, dict] 
             if key:
                 text = text.replace(key, " ")
         text = " ".join(text.split())
-        if not text:
+        if not text and not attachments:
             return None
 
     thread_id = str(message.thread_id or "").strip()
@@ -94,6 +166,7 @@ def _normalize_event(event, *, bot_open_id: str) -> tuple[ChannelInbound, dict] 
             "message": {"message_id": message_id, "chat_id": chat_id},
         },
         sender_name="",
+        attachments=attachments,
     )
     target = {
         "message_id": message_id,

--- a/backend/app/channels/schema.py
+++ b/backend/app/channels/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel
 from sqlmodel import Session
@@ -152,6 +152,7 @@ class ChannelConversationMessageRead(BaseModel):
     role: str
     content: str
     created_at: str
+    attachments: list[dict[str, Any]] | None = None
 
 
 class ChannelConversationPage(BaseModel):

--- a/backend/app/channels/schema.py
+++ b/backend/app/channels/schema.py
@@ -147,12 +147,26 @@ class ChannelConversationRead(BaseModel):
     updated_at: str
 
 
+class ChannelConversationAttachmentRead(BaseModel):
+    """会话消息附件的精简元数据视图。
+
+    仅暴露展示所需的字段，避免把 data_url(base64)、sandbox_path 等
+    内部字段或大体量内容塞进会话列表响应。
+    """
+
+    id: Optional[str] = None
+    filename: Optional[str] = None
+    content_type: Optional[str] = None
+    size: Optional[int] = None
+    kind: Optional[str] = None
+
+
 class ChannelConversationMessageRead(BaseModel):
     id: str
     role: str
     content: str
     created_at: str
-    attachments: list[dict[str, Any]] | None = None
+    attachments: list[ChannelConversationAttachmentRead] | None = None
 
 
 class ChannelConversationPage(BaseModel):

--- a/backend/app/channels/service_dingtalk_inbox.py
+++ b/backend/app/channels/service_dingtalk_inbox.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy import or_, update
 from sqlmodel import Session, select
 
-from app.channels.adapters.base import ChannelInbound
+from app.channels.adapters.base import ChannelInbound, ChannelInboundAttachment
 from app.channels.service_durable_inbox import StageDisposition, StageResult
 from app.db.models import ChannelBinding, ChannelInboundEvent, new_id, utc_now
 
@@ -42,7 +42,14 @@ def decode_replay_envelope(payload: object) -> ChannelInbound:
     allowed = set(ChannelInbound.__dataclass_fields__)
     if not set(normalized) <= allowed:
         raise ValueError("invalid_envelope_fields")
-    inbound = ChannelInbound(**normalized)
+    copy = dict(normalized)
+    raw_attachments = copy.get("attachments") or []
+    if raw_attachments:
+        copy["attachments"] = [
+            ChannelInboundAttachment(**att) if isinstance(att, dict) else att
+            for att in raw_attachments
+        ]
+    inbound = ChannelInbound(**copy)
     if inbound.channel != "dingtalk":
         raise ValueError("invalid_envelope_channel")
     return inbound

--- a/backend/app/channels/service_feishu_inbox.py
+++ b/backend/app/channels/service_feishu_inbox.py
@@ -8,7 +8,7 @@ from sqlalchemy import or_, update
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlmodel import Session, select
 
-from app.channels.adapters.base import ChannelInbound
+from app.channels.adapters.base import ChannelInbound, ChannelInboundAttachment
 from app.channels.service_durable_inbox import StageDisposition, StageResult
 from app.db.models import ChannelBinding, ChannelInboundEvent, new_id, utc_now
 
@@ -50,8 +50,15 @@ def decode_replay_envelope(payload: object) -> ChannelInbound:
     allowed = set(ChannelInbound.__dataclass_fields__)
     if not set(normalized) <= allowed:
         raise ValueError("invalid_envelope_fields")
+    copy = dict(normalized)
+    raw_attachments = copy.get("attachments") or []
+    if raw_attachments:
+        copy["attachments"] = [
+            ChannelInboundAttachment(**att) if isinstance(att, dict) else att
+            for att in raw_attachments
+        ]
     try:
-        return ChannelInbound(**normalized)
+        return ChannelInbound(**copy)
     except (TypeError, ValueError) as exc:
         raise ValueError("invalid_envelope_inbound") from exc
 

--- a/backend/app/channels/service_intake.py
+++ b/backend/app/channels/service_intake.py
@@ -928,6 +928,25 @@ def process_inbound(
                 return False
             from app.core.agent_loop import AgentLoop
 
+            attachments: list = []
+            if inbound.attachments:
+                from app.channels.attachment_bridge import inbound_attachments_to_chat
+
+                try:
+                    attachments = inbound_attachments_to_chat(
+                        binding,
+                        inbound,
+                        db_engine=use_engine,
+                        tenant_id=binding.tenant_id,
+                        user_id=user_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        "渠道附件下载失败 binding=%s event=%s",
+                        binding.id,
+                        inbound.event_id,
+                    )
+
             request = ChatTurnRequest(
                 tenant_id=binding.tenant_id,
                 session_id=session_id,
@@ -936,6 +955,7 @@ def process_inbound(
                 message=_message_text(binding, inbound),
                 channel=binding.channel,
                 client_turn_id=inbound.event_id,
+                attachments=attachments,
             )
             _send_wechat_typing(binding, inbound.from_user_id, inbound.context_token, 1, db_engine=use_engine)
             try:

--- a/backend/app/channels/service_wecom_inbox.py
+++ b/backend/app/channels/service_wecom_inbox.py
@@ -7,7 +7,7 @@ from typing import Any
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlmodel import Session, select
 
-from app.channels.adapters.base import ChannelInbound
+from app.channels.adapters.base import ChannelInbound, ChannelInboundAttachment
 from app.channels.service_durable_inbox import StageDisposition, StageResult
 from app.db.models import ChannelBinding, ChannelInboundEvent, new_id
 
@@ -36,8 +36,15 @@ def decode_wecom_replay_envelope(payload: object) -> ChannelInbound:
     allowed = set(ChannelInbound.__dataclass_fields__)
     if not set(normalized) <= allowed:
         raise ValueError("invalid_envelope_fields")
+    copy = dict(normalized)
+    raw_attachments = copy.get("attachments") or []
+    if raw_attachments:
+        copy["attachments"] = [
+            ChannelInboundAttachment(**att) if isinstance(att, dict) else att
+            for att in raw_attachments
+        ]
     try:
-        inbound = ChannelInbound(**normalized)
+        inbound = ChannelInbound(**copy)
     except (TypeError, ValueError) as exc:
         raise ValueError("invalid_envelope_inbound") from exc
     if inbound.channel != "wecom":

--- a/backend/tests/test_channel_api.py
+++ b/backend/tests/test_channel_api.py
@@ -1012,6 +1012,69 @@ def test_list_channel_conversation_messages_order_and_404() -> None:
     assert missing.status_code == 404
 
 
+def test_list_channel_conversation_messages_includes_attachments() -> None:
+    """metadata_json 中存储的 attachments 应回填到响应里。"""
+    from datetime import datetime
+
+    from app.db.models import ChatSession, Message
+
+    engine = _test_engine()
+    users = _seed_users(engine)
+    binding_id = _seed_binding(engine)
+    with Session(engine) as db:
+        db.add(
+            ChatSession(
+                id="s_att",
+                tenant_id="tenant_demo",
+                user_id="u_wx1",
+                agent_id="agent_1",
+                channel="wechat",
+                external_conv_id="wechat_p2p_u1",
+                channel_binding_id=binding_id,
+            )
+        )
+        db.add(
+            Message(
+                id="m_att",
+                tenant_id="tenant_demo",
+                session_id="s_att",
+                role="user",
+                content="看这张图",
+                created_at=datetime(2026, 7, 18, 9, 0, 0),
+                metadata_json={
+                    "attachments": [
+                        {
+                            "id": "file_abc",
+                            "filename": "photo.png",
+                            "content_type": "image/png",
+                            "size": 1024,
+                            "kind": "image",
+                        }
+                    ]
+                },
+            )
+        )
+        db.commit()
+
+    client = _make_client(engine)
+    response = client.get(
+        f"/api/enterprise/channels/{binding_id}/conversations/s_att/messages?tenant_id=tenant_demo",
+        headers=_auth(users["owner"]),
+    )
+    assert response.status_code == 200
+    rows = response.json()
+    assert len(rows) == 1
+    assert rows[0]["attachments"] == [
+        {
+            "id": "file_abc",
+            "filename": "photo.png",
+            "content_type": "image/png",
+            "size": 1024,
+            "kind": "image",
+        }
+    ]
+
+
 def test_channel_conversations_require_manager() -> None:
     engine = _test_engine()
     users = _seed_users(engine)

--- a/backend/tests/test_channel_api.py
+++ b/backend/tests/test_channel_api.py
@@ -1049,6 +1049,11 @@ def test_list_channel_conversation_messages_includes_attachments() -> None:
                             "content_type": "image/png",
                             "size": 1024,
                             "kind": "image",
+                            # 内部/大体量字段不应回传给渠道管理页面
+                            "data_url": "data:image/png;base64,iVBORw0KGgo=",
+                            "sandbox_path": "/sandbox/attachments/photo.png",
+                            "sha256": "abc123",
+                            "text": "secret",
                         }
                     ]
                 },

--- a/backend/tests/test_channel_attachment_bridge.py
+++ b/backend/tests/test_channel_attachment_bridge.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 # 触发 feishu/钉钉适配器注册到全局 _adapters,便于测试中保存/恢复 previous
 import app.channels.adapters.dingtalk
 import app.channels.adapters.feishu  # noqa: F401
@@ -15,9 +17,12 @@ from app.channels.adapters.base import (
     ChannelInboundAttachment,
     get_channel_adapter,
     register_channel_adapter,
+    stream_download_with_limit,
 )
 from app.channels.attachment_bridge import (
     MAX_CHANNEL_MEDIA_BYTES,
+    _detect_image_type,
+    _resolve_content_type,
     inbound_attachments_to_chat,
 )
 from app.channels.crypto import encrypt_channel_secret
@@ -32,7 +37,7 @@ class _FakeAdapter:
         self._download_result = download_result
         self.download_calls: list[tuple[ChannelBinding, ChannelInboundAttachment]] = []
 
-    def download_media(self, binding, attachment):
+    def download_media(self, binding, attachment, *, max_bytes=0):
         self.download_calls.append((binding, attachment))
         if isinstance(self._download_result, Exception):
             raise self._download_result
@@ -220,7 +225,14 @@ def test_bridge_skips_empty_download_result() -> None:
 def test_bridge_skips_oversized_attachment() -> None:
     """超过 MAX_CHANNEL_MEDIA_BYTES 的附件被跳过。"""
     oversized = b"x" * (MAX_CHANNEL_MEDIA_BYTES + 1)
-    fake_adapter = _FakeAdapter(oversized)
+
+    class OversizedAdapter:
+        def download_media(self, binding, attachment, *, max_bytes=0):
+            if max_bytes and len(oversized) > max_bytes:
+                raise ValueError(f"下载内容超过上限 {max_bytes} bytes")
+            return oversized
+
+    fake_adapter = OversizedAdapter()
     previous = get_channel_adapter("feishu")
     register_channel_adapter("feishu", fake_adapter)
     try:
@@ -239,7 +251,7 @@ def test_bridge_continues_on_single_attachment_failure() -> None:
     call_count = {"n": 0}
 
     class MixedAdapter:
-        def download_media(self, binding, attachment):
+        def download_media(self, binding, attachment, *, max_bytes=0):
             call_count["n"] += 1
             if call_count["n"] == 1:
                 raise RuntimeError("network down")
@@ -305,3 +317,101 @@ def test_bridge_passes_empty_content_type_as_none() -> None:
         assert args[2] == b"some bytes"
     finally:
         register_channel_adapter("feishu", previous)
+
+
+def test_detect_image_type_recognizes_common_formats() -> None:
+    """magic bytes 签名能识别 PNG/JPEG/GIF/WebP/BMP。"""
+    assert _detect_image_type(b"\x89PNG\r\n\x1a\n" + b"\x00" * 20) == ("image/png", ".png")
+    assert _detect_image_type(b"\xff\xd8\xff\xe0" + b"\x00" * 20) == ("image/jpeg", ".jpg")
+    assert _detect_image_type(b"GIF89a" + b"\x00" * 20) == ("image/gif", ".gif")
+    assert _detect_image_type(b"RIFF" + b"\x00" * 4 + b"WEBP" + b"\x00" * 20) == ("image/webp", ".webp")
+    assert _detect_image_type(b"BM" + b"\x00" * 20) == ("image/bmp", ".bmp")
+
+
+def test_detect_image_type_rejects_non_image_data() -> None:
+    """非图片字节或太短的数据返回 None。"""
+    assert _detect_image_type(b"") is None
+    assert _detect_image_type(b"short") is None
+    assert _detect_image_type(b"RIFF" + b"\x00" * 4 + b"XXXX" + b"\x00" * 20) is None
+
+
+def test_resolve_content_type_overrides_with_magic_bytes() -> None:
+    """下载后用 magic bytes 覆盖渠道侧空的 content_type 和 filename。"""
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+    ct, fn = _resolve_content_type("", "img_v3_001", png)
+    assert ct == "image/png"
+    assert fn == "img_v3_001.png"
+
+
+def test_resolve_content_type_preserves_existing_filename_extension() -> None:
+    """filename 已含正确扩展名时不重复追加。"""
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+    ct, fn = _resolve_content_type("", "photo.png", png)
+    assert ct == "image/png"
+    assert fn == "photo.png"
+
+
+def test_resolve_content_type_passes_through_non_image() -> None:
+    """非图片文件保留渠道侧 content_type,空则返回 None。"""
+    ct, fn = _resolve_content_type("", "report.pdf", b"%PDF-1.4")
+    assert ct is None
+    assert fn == "report.pdf"
+
+    ct, fn = _resolve_content_type("application/pdf", "report.pdf", b"%PDF-1.4")
+    assert ct == "application/pdf"
+    assert fn == "report.pdf"
+
+
+def test_stream_download_with_limit_enforces_content_length() -> None:
+    """Content-Length 超限时立即中止,不读取响应体。"""
+    import httpx
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-length": "100"},
+            content=b"x" * 100,
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport)
+    try:
+        with pytest.raises(ValueError, match="超过上限"):
+            stream_download_with_limit(client, "GET", "https://x/test", max_bytes=50)
+    finally:
+        client.close()
+
+
+def test_stream_download_with_limit_enforces_streamed_body() -> None:
+    """无 Content-Length 时流式累计读取超限即中止。"""
+    import httpx
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"x" * 200)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport)
+    try:
+        with pytest.raises(ValueError, match="超过上限"):
+            stream_download_with_limit(client, "GET", "https://x/test", max_bytes=100)
+    finally:
+        client.close()
+
+
+def test_stream_download_with_limit_returns_body_when_under_limit() -> None:
+    """未超限时正常返回 body。"""
+    import httpx
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"hello world")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport)
+    try:
+        status, data = stream_download_with_limit(
+            client, "GET", "https://x/test", max_bytes=100,
+        )
+        assert status == 200
+        assert data == b"hello world"
+    finally:
+        client.close()

--- a/backend/tests/test_channel_attachment_bridge.py
+++ b/backend/tests/test_channel_attachment_bridge.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# 触发 feishu/钉钉适配器注册到全局 _adapters,便于测试中保存/恢复 previous
+import app.channels.adapters.dingtalk
+import app.channels.adapters.feishu  # noqa: F401
+
+# 通过 app.api.chat 完整加载 app.core / app.session 依赖链,
+# 之后才能正常 import app.session.attachment_store / app.session.attachments
+from app.api.chat import _user_message_metadata  # noqa: F401
+from app.channels.adapters.base import (
+    ChannelInbound,
+    ChannelInboundAttachment,
+    get_channel_adapter,
+    register_channel_adapter,
+)
+from app.channels.attachment_bridge import (
+    MAX_CHANNEL_MEDIA_BYTES,
+    inbound_attachments_to_chat,
+)
+from app.channels.crypto import encrypt_channel_secret
+from app.db.models import ChannelBinding
+from app.session.session_schema import ChatAttachmentRead
+
+
+class _FakeAdapter:
+    """模拟适配器:download_media 返回预设字节,用于隔离 attachment_bridge 测试。"""
+
+    def __init__(self, download_result: bytes | Exception):
+        self._download_result = download_result
+        self.download_calls: list[tuple[ChannelBinding, ChannelInboundAttachment]] = []
+
+    def download_media(self, binding, attachment):
+        self.download_calls.append((binding, attachment))
+        if isinstance(self._download_result, Exception):
+            raise self._download_result
+        return self._download_result
+
+
+def _binding() -> ChannelBinding:
+    return ChannelBinding(
+        id="chan_test",
+        tenant_id="tenant_a",
+        agent_id="agent_a",
+        channel="feishu",
+        status="active",
+        config_json={"app_id": "cli_app"},
+        credentials_enc=encrypt_channel_secret("secret"),
+        config_revision=1,
+    )
+
+
+def _inbound(attachments: list[ChannelInboundAttachment]) -> ChannelInbound:
+    return ChannelInbound(
+        channel="feishu",
+        event_id="evt_1",
+        from_user_id="ou_sender",
+        to_user_id="ou_bot",
+        session_id="oc_chat",
+        group_id="",
+        context_token="om_msg",
+        text="",
+        is_group=False,
+        raw={},
+        attachments=attachments,
+    )
+
+
+def _staged_attachment(filename: str = "img.jpg", content_type: str = "image/jpeg") -> ChatAttachmentRead:
+    return ChatAttachmentRead(
+        id="file_1",
+        filename=filename,
+        content_type=content_type,
+        size=4,
+        kind="image",
+        data_url=f"data:{content_type};base64,AAAA",
+        sha256="abc123",
+        sandbox_path="/workspace/attachments/file_1-img.jpg",
+    )
+
+
+def test_channel_inbound_attachments_defaults_to_empty_list() -> None:
+    inbound = ChannelInbound(
+        channel="feishu",
+        event_id="e",
+        from_user_id="u",
+        to_user_id="b",
+        session_id="s",
+        group_id="",
+        context_token="c",
+        text="hi",
+        is_group=False,
+        raw={},
+    )
+    assert inbound.attachments == []
+    # 独立实例,不共享默认值
+    assert inbound.attachments is not ChannelInbound(
+        channel="feishu",
+        event_id="e2",
+        from_user_id="u",
+        to_user_id="b",
+        session_id="s",
+        group_id="",
+        context_token="c",
+        text="hi",
+        is_group=False,
+        raw={},
+    ).attachments
+
+
+def test_channel_inbound_attachment_construction() -> None:
+    att = ChannelInboundAttachment(
+        media_id="img_key",
+        kind="image",
+        filename="x.jpg",
+        content_type="image/jpeg",
+        size=10,
+        download_params={"file_key": "img_key"},
+    )
+    assert att.media_id == "img_key"
+    assert att.kind == "image"
+    assert att.download_params["file_key"] == "img_key"
+
+    # 默认 download_params 为独立空字典
+    default_att = ChannelInboundAttachment(media_id="m", kind="file")
+    assert default_att.download_params == {}
+    assert default_att.filename == ""
+    assert default_att.content_type == ""
+    assert default_att.size == 0
+
+
+def test_bridge_returns_empty_when_adapter_has_no_download_media() -> None:
+    """适配器未实现 download_media 时返回空列表,不阻塞。"""
+    adapter = SimpleNamespace()  # 没有 download_media 属性
+    previous = get_channel_adapter("feishu")
+    register_channel_adapter("feishu", adapter)
+    try:
+        inbound = _inbound([ChannelInboundAttachment(media_id="m", kind="image")])
+        result = inbound_attachments_to_chat(
+            _binding(),
+            inbound,
+            db_engine=None,
+            tenant_id="t",
+            user_id="u",
+        )
+        assert result == []
+    finally:
+        register_channel_adapter("feishu", previous)
+
+
+def test_bridge_downloads_and_stages_attachments() -> None:
+    """完整链路:download_media -> parse_chat_attachment -> stage_chat_attachment。"""
+    fake_adapter = _FakeAdapter(b"PNG-data")
+    previous = get_channel_adapter("feishu")
+    register_channel_adapter("feishu", fake_adapter)
+    try:
+        attachment = ChannelInboundAttachment(
+            media_id="img_v3_001",
+            kind="image",
+            filename="img_v3_001.jpg",
+            content_type="image/jpeg",
+            download_params={"file_key": "img_v3_001", "type": "image", "message_id": "om_1"},
+        )
+        inbound = _inbound([attachment])
+
+        staged = _staged_attachment(filename="img_v3_001.jpg")
+        with (
+            patch(
+                "app.session.attachments.parse_chat_attachment",
+                return_value=staged,
+            ) as mock_parse,
+            patch(
+                "app.session.attachment_store.stage_chat_attachment",
+                return_value=staged.model_copy(
+                    update={"sha256": "real_sha", "sandbox_path": "/ws/x"}
+                ),
+            ) as mock_stage,
+        ):
+            results = inbound_attachments_to_chat(
+                _binding(),
+                inbound,
+                db_engine=None,
+                tenant_id="tenant_a",
+                user_id="user_1",
+            )
+
+        assert len(results) == 1
+        assert results[0].sha256 == "real_sha"
+        assert results[0].sandbox_path == "/ws/x"
+        # download_media 被调用一次,参数正确
+        assert len(fake_adapter.download_calls) == 1
+        assert fake_adapter.download_calls[0][1].media_id == "img_v3_001"
+        # parse_chat_attachment 收到原始字节和文件名
+        mock_parse.assert_called_once_with("img_v3_001.jpg", "image/jpeg", b"PNG-data")
+        # stage_chat_attachment 收到 attachment + 字节 + tenant/user
+        mock_stage.assert_called_once()
+        stage_kwargs = mock_stage.call_args.kwargs
+        assert stage_kwargs["tenant_id"] == "tenant_a"
+        assert stage_kwargs["user_id"] == "user_1"
+    finally:
+        register_channel_adapter("feishu", previous)
+
+
+def test_bridge_skips_empty_download_result() -> None:
+    fake_adapter = _FakeAdapter(b"")
+    previous = get_channel_adapter("feishu")
+    register_channel_adapter("feishu", fake_adapter)
+    try:
+        inbound = _inbound([ChannelInboundAttachment(media_id="m", kind="image")])
+        results = inbound_attachments_to_chat(
+            _binding(), inbound, db_engine=None, tenant_id="t", user_id="u"
+        )
+        assert results == []
+    finally:
+        register_channel_adapter("feishu", previous)
+
+
+def test_bridge_skips_oversized_attachment() -> None:
+    """超过 MAX_CHANNEL_MEDIA_BYTES 的附件被跳过。"""
+    oversized = b"x" * (MAX_CHANNEL_MEDIA_BYTES + 1)
+    fake_adapter = _FakeAdapter(oversized)
+    previous = get_channel_adapter("feishu")
+    register_channel_adapter("feishu", fake_adapter)
+    try:
+        inbound = _inbound([ChannelInboundAttachment(media_id="big", kind="file")])
+        results = inbound_attachments_to_chat(
+            _binding(), inbound, db_engine=None, tenant_id="t", user_id="u"
+        )
+        assert results == []
+    finally:
+        register_channel_adapter("feishu", previous)
+
+
+def test_bridge_continues_on_single_attachment_failure() -> None:
+    """单个附件下载异常不影响其他附件。"""
+    good = b"PNG-data"
+    call_count = {"n": 0}
+
+    class MixedAdapter:
+        def download_media(self, binding, attachment):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("network down")
+            return good
+
+    previous = get_channel_adapter("feishu")
+    register_channel_adapter("feishu", MixedAdapter())
+    try:
+        inbound = _inbound([
+            ChannelInboundAttachment(media_id="bad", kind="image"),
+            ChannelInboundAttachment(media_id="good", kind="image", filename="g.jpg"),
+        ])
+        staged = _staged_attachment(filename="g.jpg")
+        with (
+            patch(
+                "app.session.attachments.parse_chat_attachment",
+                return_value=staged,
+            ),
+            patch(
+                "app.session.attachment_store.stage_chat_attachment",
+                return_value=staged.model_copy(update={"sha256": "sha"}),
+            ),
+        ):
+            results = inbound_attachments_to_chat(
+                _binding(), inbound, db_engine=None, tenant_id="t", user_id="u"
+            )
+        # 第一个失败被吞,第二个成功
+        assert len(results) == 1
+        assert call_count["n"] == 2
+    finally:
+        register_channel_adapter("feishu", previous)
+
+
+def test_bridge_passes_empty_content_type_as_none() -> None:
+    """att.content_type 为空字符串时传 None 给 parse_chat_attachment(让其自动推断)。"""
+    fake_adapter = _FakeAdapter(b"some bytes")
+    previous = get_channel_adapter("feishu")
+    register_channel_adapter("feishu", fake_adapter)
+    try:
+        inbound = _inbound([
+            ChannelInboundAttachment(
+                media_id="f_key", kind="file", filename="report.pdf", content_type=""
+            )
+        ])
+        staged = _staged_attachment(filename="report.pdf", content_type="application/pdf")
+        with (
+            patch(
+                "app.session.attachments.parse_chat_attachment",
+                return_value=staged,
+            ) as mock_parse,
+            patch(
+                "app.session.attachment_store.stage_chat_attachment",
+                return_value=staged,
+            ),
+        ):
+            inbound_attachments_to_chat(
+                _binding(), inbound, db_engine=None, tenant_id="t", user_id="u"
+            )
+        # content_type="" -> None
+        args, _kwargs = mock_parse.call_args
+        assert args[0] == "report.pdf"
+        assert args[1] is None
+        assert args[2] == b"some bytes"
+    finally:
+        register_channel_adapter("feishu", previous)

--- a/backend/tests/test_channel_dingtalk.py
+++ b/backend/tests/test_channel_dingtalk.py
@@ -19,8 +19,10 @@ from app.channels.adapters.dingtalk import (
 )
 from app.channels.crypto import encrypt_channel_secret
 from app.channels.service_dingtalk_inbox import (
+    decode_replay_envelope,
     dingtalk_account_key,
     dingtalk_identity_scope,
+    encode_replay_envelope,
     stage_dingtalk_inbound,
 )
 from app.channels.service_durable_inbox import StageDisposition
@@ -157,9 +159,10 @@ def test_send_rejects_untrusted_webhook_and_uses_injected_client():
 
 
 class _Response:
-    def __init__(self, status_code=200, payload=None):
+    def __init__(self, status_code=200, payload=None, content: bytes = b""):
         self.status_code = status_code
         self._payload = {} if payload is None else payload
+        self.content = content
 
     def json(self):
         return self._payload
@@ -178,12 +181,18 @@ class _RoutingClient:
     def __exit__(self, *_args):
         return False
 
-    def post(self, url, json=None, headers=None, **_kwargs):
-        self.calls.append({"url": url, "body": json, "headers": headers or {}})
+    def _route(self, url, body, headers, method):
+        self.calls.append({"url": url, "body": body, "headers": headers or {}, "method": method})
         for fragment, queue in self.routes.items():
             if fragment in url:
                 return queue.pop(0) if len(queue) > 1 else queue[0]
         raise AssertionError(f"未预期的请求地址 {url}")
+
+    def post(self, url, json=None, headers=None, **_kwargs):
+        return self._route(url, json, headers, "POST")
+
+    def get(self, url, headers=None, **_kwargs):
+        return self._route(url, None, headers, "GET")
 
     def calls_to(self, fragment):
         return [call for call in self.calls if fragment in call["url"]]
@@ -417,3 +426,252 @@ def test_dingtalk_token_errors_are_classified():
     )
     with pytest.raises(DingTalkTransientError):
         missing_field.get(binding)
+
+
+def test_normalize_dingtalk_picture_message_extracts_attachment() -> None:
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    raw = _raw(
+        msgtype="picture",
+        content={"downloadCode": "dc_001", "pictureDownloadCode": "dc_001"},
+    )
+    inbound = normalize_dingtalk_message(raw)
+    assert inbound is not None
+    # 图片消息无文本,但附件存在所以不再被丢弃
+    assert inbound.text == ""
+    assert len(inbound.attachments) == 1
+    att = inbound.attachments[0]
+    assert isinstance(att, ChannelInboundAttachment)
+    assert att.media_id == "dc_001"
+    assert att.kind == "image"
+    assert att.filename == "dc_001.jpg"
+    assert att.content_type == "image/jpeg"
+    assert att.download_params == {"download_code": "dc_001", "type": "picture"}
+
+
+def test_normalize_dingtalk_file_message_extracts_attachment_with_filename() -> None:
+    raw = _raw(
+        msgtype="file",
+        content={"downloadCode": "dc_002", "fileName": "report.pdf"},
+    )
+    inbound = normalize_dingtalk_message(raw)
+    assert inbound is not None
+    assert inbound.text == ""
+    assert len(inbound.attachments) == 1
+    att = inbound.attachments[0]
+    assert att.media_id == "dc_002"
+    assert att.kind == "file"
+    assert att.filename == "report.pdf"
+    assert att.content_type == ""
+    assert att.download_params == {"download_code": "dc_002", "type": "file"}
+
+
+def test_normalize_dingtalk_text_message_has_empty_attachments() -> None:
+    """纯文本消息仍正常工作,attachments 为空列表。"""
+    inbound = normalize_dingtalk_message(_raw())
+    assert inbound is not None
+    assert inbound.text == "hello"
+    assert inbound.attachments == []
+
+
+def test_normalize_dingtalk_picture_without_download_code_returns_none() -> None:
+    """picture 消息但缺 downloadCode 时返回 None(无文本也无附件)。"""
+    raw = _raw(msgtype="picture", content={})
+    assert normalize_dingtalk_message(raw) is None
+
+
+def test_normalize_dingtalk_picture_in_group_requires_at() -> None:
+    """群聊 picture 消息仍需 isInAtList=True 才通过。"""
+    raw = _raw(
+        msgtype="picture",
+        conversationType="2",
+        isInAtList=False,
+        content={"downloadCode": "dc_group"},
+    )
+    assert normalize_dingtalk_message(raw) is None
+
+    raw_ok = _raw(
+        msgtype="picture",
+        conversationType="2",
+        isInAtList=True,
+        content={"downloadCode": "dc_group_ok"},
+    )
+    inbound = normalize_dingtalk_message(raw_ok)
+    assert inbound is not None
+    assert inbound.is_group is True
+    assert len(inbound.attachments) == 1
+    assert inbound.attachments[0].media_id == "dc_group_ok"
+
+
+def _download_media_adapter(*, token_responses=None, download_responses=None,
+                            file_response=None):
+    """构造用于 download_media 测试的 adapter + client。
+
+    token_responses: oauth2/accessToken 队列
+    download_responses: messageFiles/download 队列(返回 downloadUrl JSON)
+    file_response: 第二步 GET downloadUrl 的 _Response
+    """
+    routes = {
+        "oauth2/accessToken": token_responses or _token_route("token-1"),
+        "robot/messageFiles/download": download_responses
+        or [_Response(200, {"downloadUrl": "https://download.example/file.bin"})],
+        "download.example": [file_response or _Response(200, content=b"FILE-BYTES")],
+    }
+    client = _RoutingClient(routes)
+    return DingTalkAdapter(client_factory=lambda: client), client
+
+
+def test_download_media_calls_two_step_download() -> None:
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    adapter, client = _download_media_adapter(
+        file_response=_Response(200, content=b"FILE-BYTES"),
+    )
+    att = ChannelInboundAttachment(
+        media_id="dc_001",
+        kind="file",
+        filename="report.pdf",
+        download_params={"download_code": "dc_001", "type": "file"},
+    )
+    data = adapter.download_media(_reaction_binding(), att)
+    assert data == b"FILE-BYTES"
+
+    # 第一步: POST messageFiles/download
+    download_call = client.calls_to("robot/messageFiles/download")[0]
+    assert download_call["method"] == "POST"
+    assert download_call["body"] == {"downloadCode": "dc_001", "robotCode": "client-1"}
+    assert download_call["headers"]["x-acs-dingtalk-access-token"] == "token-1"
+    assert download_call["headers"]["Content-Type"] == "application/json"
+
+    # 第二步: GET downloadUrl
+    file_call = client.calls_to("download.example")[0]
+    assert file_call["method"] == "GET"
+    assert file_call["url"] == "https://download.example/file.bin"
+
+
+def test_download_media_missing_download_code_is_permanent_error() -> None:
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    adapter, _client = _download_media_adapter()
+    att = ChannelInboundAttachment(
+        media_id="",
+        kind="file",
+        download_params={"download_code": "", "type": "file"},
+    )
+    with pytest.raises(DingTalkPermanentError, match="缺少 downloadCode"):
+        adapter.download_media(_reaction_binding(), att)
+
+
+def test_download_media_missing_download_url_is_permanent_error() -> None:
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    # 响应 200 但缺 downloadUrl
+    adapter, _client = _download_media_adapter(
+        download_responses=[_Response(200, {})],
+    )
+    att = ChannelInboundAttachment(
+        media_id="dc_x",
+        kind="file",
+        download_params={"download_code": "dc_x", "type": "file"},
+    )
+    with pytest.raises(DingTalkPermanentError, match="缺少 downloadUrl"):
+        adapter.download_media(_reaction_binding(), att)
+
+
+def test_download_media_refreshes_token_on_401() -> None:
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    adapter, client = _download_media_adapter(
+        token_responses=_token_route("stale-token", "fresh-token"),
+        download_responses=[
+            _Response(401),  # 第一次 401
+            _Response(200, {"downloadUrl": "https://download.example/file.bin"}),
+        ],
+        file_response=_Response(200, content=b"OK"),
+    )
+    att = ChannelInboundAttachment(
+        media_id="dc_001",
+        kind="file",
+        download_params={"download_code": "dc_001", "type": "file"},
+    )
+    data = adapter.download_media(_reaction_binding(), att)
+    assert data == b"OK"
+
+    download_calls = client.calls_to("robot/messageFiles/download")
+    assert len(download_calls) == 2
+    tokens_used = [c["headers"]["x-acs-dingtalk-access-token"] for c in download_calls]
+    assert tokens_used == ["stale-token", "fresh-token"]
+    # token 刷新两次
+    assert len(client.calls_to("oauth2/accessToken")) == 2
+
+
+def test_download_media_5xx_on_first_step_is_transient() -> None:
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    adapter, _client = _download_media_adapter(
+        download_responses=[_Response(503)],
+    )
+    att = ChannelInboundAttachment(
+        media_id="dc_001",
+        kind="file",
+        download_params={"download_code": "dc_001", "type": "file"},
+    )
+    with pytest.raises(DingTalkTransientError, match="暂时不可用"):
+        adapter.download_media(_reaction_binding(), att)
+
+
+def test_download_media_non_200_on_second_step_is_transient() -> None:
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    adapter, _client = _download_media_adapter(
+        file_response=_Response(404, content=b""),
+    )
+    att = ChannelInboundAttachment(
+        media_id="dc_001",
+        kind="file",
+        download_params={"download_code": "dc_001", "type": "file"},
+    )
+    with pytest.raises(DingTalkTransientError, match="HTTP 404"):
+        adapter.download_media(_reaction_binding(), att)
+
+
+def test_envelope_round_trips_attachments_as_dataclass() -> None:
+    from app.channels.adapters.base import ChannelInbound, ChannelInboundAttachment
+
+    inbound = ChannelInbound(
+        channel="dingtalk",
+        event_id="msg_att_1",
+        from_user_id="staff-1",
+        to_user_id="robot-1",
+        session_id="conv-1",
+        group_id="",
+        context_token="https://example.test/reply",
+        text="",
+        is_group=False,
+        raw={"msgId": "msg_att_1"},
+        sender_name="Alice",
+        account_scope="corp-1",
+        attachments=[
+            ChannelInboundAttachment(
+                media_id="dc_001",
+                kind="picture",
+                download_params={"download_code": "dc_001", "type": "picture"},
+            ),
+            ChannelInboundAttachment(
+                media_id="dc_002",
+                kind="file",
+                filename="report.xlsx",
+                content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                download_params={"download_code": "dc_002", "type": "file"},
+            ),
+        ],
+    )
+    envelope = encode_replay_envelope(inbound, client_id="client-1", tenant_key="corp-1")
+    decoded = decode_replay_envelope(envelope)
+    assert len(decoded.attachments) == 2
+    for att in decoded.attachments:
+        assert isinstance(att, ChannelInboundAttachment)
+    assert decoded.attachments[0].media_id == "dc_001"
+    assert decoded.attachments[0].download_params["download_code"] == "dc_001"
+    assert decoded.attachments[1].filename == "report.xlsx"
+    assert decoded.attachments[1].kind == "file"

--- a/backend/tests/test_channel_dingtalk.py
+++ b/backend/tests/test_channel_dingtalk.py
@@ -444,8 +444,8 @@ def test_normalize_dingtalk_picture_message_extracts_attachment() -> None:
     assert isinstance(att, ChannelInboundAttachment)
     assert att.media_id == "dc_001"
     assert att.kind == "image"
-    assert att.filename == "dc_001.jpg"
-    assert att.content_type == "image/jpeg"
+    assert att.filename == "dc_001"  # 不在 normalize 阶段硬编码扩展名
+    assert att.content_type == ""  # 下载后由 _resolve_content_type 推断
     assert att.download_params == {"download_code": "dc_001", "type": "picture"}
 
 
@@ -501,6 +501,44 @@ def test_normalize_dingtalk_picture_in_group_requires_at() -> None:
     assert inbound.is_group is True
     assert len(inbound.attachments) == 1
     assert inbound.attachments[0].media_id == "dc_group_ok"
+
+
+def test_normalize_dingtalk_richtext_extracts_attachment_and_text() -> None:
+    """richtext 消息提取图片附件和文本。"""
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    raw = _raw(
+        msgtype="richText",
+        conversationType="2",
+        isInAtList=True,
+        content={
+            "richText": [
+                {"type": "picture", "downloadCode": "dc_rt_1", "pictureDownloadCode": "dc_rt_1"},
+                {"text": "\n"},
+                {"text": "@staffdeck渠道接入测试机器人"},
+            ]
+        },
+    )
+    inbound = normalize_dingtalk_message(raw)
+    assert inbound is not None
+    assert inbound.is_group is True
+    assert len(inbound.attachments) == 1
+    att = inbound.attachments[0]
+    assert isinstance(att, ChannelInboundAttachment)
+    assert att.media_id == "dc_rt_1"
+    assert att.kind == "image"
+    assert att.download_params == {"download_code": "dc_rt_1", "type": "picture"}
+    # richtext 文本被拼接,@mention 被 strip
+    assert inbound.text == ""
+
+
+def test_normalize_dingtalk_richtext_without_download_code_returns_none() -> None:
+    """richtext 消息但无 picture downloadCode 且无文本时返回 None。"""
+    raw = _raw(
+        msgtype="richText",
+        content={"richText": [{"type": "picture"}, {"text": "\n"}]},
+    )
+    assert normalize_dingtalk_message(raw) is None
 
 
 def _download_media_adapter(*, token_responses=None, download_responses=None,

--- a/backend/tests/test_channel_intake.py
+++ b/backend/tests/test_channel_intake.py
@@ -945,3 +945,94 @@ def test_concurrent_sweeps_stage_one_incomplete_notice(tmp_path) -> None:
             select(ChannelDelivery).where(ChannelDelivery.kind == "error_notice")
         ).all()
         assert len(notices) == 1
+
+
+def test_inbound_attachment_download_failure_degrades_to_text(monkeypatch) -> None:
+    """渠道附件下载异常时不阻塞文本轮,降级为纯文本处理。"""
+    from app.channels.adapters.base import ChannelInbound, ChannelInboundAttachment
+    import app.channels.attachment_bridge as bridge_module
+
+    engine = _test_engine()
+    binding_id = _seed_binding(engine)
+    binding = _load_binding(engine, binding_id)
+
+    # 构造一个带附件的 wechat 入站消息(wechat 适配器未实现 download_media,
+    # bridge 会返回空列表;这里进一步模拟 inbound_attachments_to_chat 抛异常
+    # 来验证 intake 的 try/except 降级路径)
+    inbound = ChannelInbound(
+        channel="wechat",
+        event_id="evt_att_fail",
+        from_user_id="user_ab12cd34@im.wechat",
+        to_user_id="bot_1@im.bot",
+        session_id="user_ab12cd34@im.wechat#bot_1@im.bot",
+        group_id="",
+        context_token="ctx_att_fail",
+        text="看这张图",
+        is_group=False,
+        raw={},
+        attachments=[ChannelInboundAttachment(media_id="img_1", kind="image")],
+    )
+
+    # 让 inbound_attachments_to_chat 抛异常,验证 intake 降级
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("下载服务不可用")
+
+    monkeypatch.setattr(bridge_module, "inbound_attachments_to_chat", _boom)
+
+    assert process_inbound(binding, inbound, db_engine=engine) is True
+    # 仍然执行了对话轮
+    assert len(RecordingAgentLoop.calls) == 1
+    request = RecordingAgentLoop.calls[0]
+    # 降级为纯文本:attachments 为空列表
+    assert request.attachments == []
+    assert request.message == "看这张图"
+
+    with Session(engine) as db:
+        event = db.exec(select(ChannelInboundEvent)).one()
+        assert event.status == "done"
+
+
+def test_inbound_with_attachments_passes_them_to_request(monkeypatch) -> None:
+    """附件下载成功时,attachments 被填入 ChatTurnRequest。"""
+    from app.channels.adapters.base import ChannelInbound, ChannelInboundAttachment
+    import app.channels.attachment_bridge as bridge_module
+    from app.session.session_schema import ChatAttachmentRead
+
+    engine = _test_engine()
+    binding_id = _seed_binding(engine)
+    binding = _load_binding(engine, binding_id)
+
+    inbound = ChannelInbound(
+        channel="wechat",
+        event_id="evt_att_ok",
+        from_user_id="user_ab12cd34@im.wechat",
+        to_user_id="bot_1@im.bot",
+        session_id="user_ab12cd34@im.wechat#bot_1@im.bot",
+        group_id="",
+        context_token="ctx_att_ok",
+        text="",
+        is_group=False,
+        raw={},
+        attachments=[ChannelInboundAttachment(media_id="img_1", kind="image")],
+    )
+
+    staged = ChatAttachmentRead(
+        id="file_1",
+        filename="img.jpg",
+        content_type="image/jpeg",
+        size=4,
+        kind="image",
+        sha256="abc",
+        sandbox_path="/ws/x",
+    )
+
+    def _fake_bridge(*_args, **_kwargs):
+        return [staged]
+
+    monkeypatch.setattr(bridge_module, "inbound_attachments_to_chat", _fake_bridge)
+
+    assert process_inbound(binding, inbound, db_engine=engine) is True
+    request = RecordingAgentLoop.calls[0]
+    assert len(request.attachments) == 1
+    assert request.attachments[0].filename == "img.jpg"
+    assert request.attachments[0].sha256 == "abc"

--- a/backend/tests/test_feishu_adapter.py
+++ b/backend/tests/test_feishu_adapter.py
@@ -553,8 +553,8 @@ def test_normalize_image_message_extracts_attachment() -> None:
     assert isinstance(att, ChannelInboundAttachment)
     assert att.media_id == "img_v3_001"
     assert att.kind == "image"
-    assert att.filename == "img_v3_001.jpg"
-    assert att.content_type == "image/jpeg"
+    assert att.filename == "img_v3_001"  # 不在 normalize 阶段硬编码扩展名
+    assert att.content_type == ""  # 下载后由 _resolve_content_type 推断
     assert att.download_params == {
         "file_key": "img_v3_001",
         "type": "image",
@@ -600,17 +600,22 @@ def test_normalize_image_without_image_key_returns_none() -> None:
     assert _normalize_event(event, bot_open_id="ou_bot") is None
 
 
-def test_normalize_group_attachment_requires_bot_mention() -> None:
-    """群聊 image/file 消息仍需 @ 机器人才能通过。"""
-    # 不带 @ 机器人
+def test_normalize_group_attachment_without_mention_is_accepted() -> None:
+    """群聊 image/file 消息天然不携带 mentions,无需 @ 机器人即可通过。"""
+    # 不带 @ 机器人 → 仍接受(image 消息无法携带 mentions)
     event_no_mention = _p2p_event(
         message_type="image",
         content={"image_key": "img_v3_002"},
         chat_type="group",
     )
-    assert _normalize_event(event_no_mention, bot_open_id="ou_bot") is None
+    result = _normalize_event(event_no_mention, bot_open_id="ou_bot")
+    assert result is not None
+    inbound, _target = result
+    assert inbound.is_group is True
+    assert len(inbound.attachments) == 1
+    assert inbound.attachments[0].media_id == "img_v3_002"
 
-    # 带 @ 机器人
+    # 带 @ 机器人的 text+image 也正常
     event = _group_attachment_event("image", {"image_key": "img_v3_003"})
     result = _normalize_event(event, bot_open_id="ou_bot")
     assert result is not None

--- a/backend/tests/test_feishu_adapter.py
+++ b/backend/tests/test_feishu_adapter.py
@@ -742,3 +742,201 @@ def test_download_media_5xx_is_transient() -> None:
     )
     with pytest.raises(FeishuTransientError, match="暂时不可用"):
         adapter.download_media(_binding(), att)
+
+
+def _group_post_event(content: dict, mentions: list | None = None) -> object:
+    """构造飞书群聊 post(富文本)消息 event。"""
+    message = SimpleNamespace(
+        message_id="om_post",
+        chat_id="oc_group",
+        chat_type="group",
+        message_type="post",
+        content=json.dumps(content),
+        mentions=mentions or [],
+        thread_id="",
+        root_id="",
+    )
+    return SimpleNamespace(
+        header=SimpleNamespace(app_id="cli_app", tenant_key="tenant_key"),
+        event=SimpleNamespace(
+            message=message,
+            sender=SimpleNamespace(
+                sender_id=SimpleNamespace(open_id="ou_sender"),
+                sender_type="user",
+            ),
+        ),
+    )
+
+
+def test_normalize_post_message_extracts_image_and_text() -> None:
+    """群聊 post 消息(图片+@机器人+文本)应提取图片附件和文本,不再被丢弃。"""
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    content = {
+        "zh_cn": {
+            "title": "",
+            "content": [
+                [{"tag": "img", "image_key": "img_v3_post_1"}],
+                [
+                    {"tag": "at", "user_id": "ou_bot"},
+                    {"tag": "text", "text": " 看这张图"},
+                ],
+            ],
+        }
+    }
+    mentions = [
+        SimpleNamespace(
+            id=SimpleNamespace(open_id="ou_bot"),
+            key="@_user_1",
+            mentioned_type="bot",
+        )
+    ]
+    event = _group_post_event(content, mentions=mentions)
+    result = _normalize_event(event, bot_open_id="ou_bot")
+    assert result is not None
+    inbound, target = result
+    assert inbound.is_group is True
+    assert len(inbound.attachments) == 1
+    att = inbound.attachments[0]
+    assert isinstance(att, ChannelInboundAttachment)
+    assert att.media_id == "img_v3_post_1"
+    assert att.kind == "image"
+    assert att.download_params == {
+        "file_key": "img_v3_post_1",
+        "type": "image",
+        "message_id": "om_post",
+    }
+    assert inbound.text == "看这张图"
+    assert target["receive_id_type"] == "chat_id"
+    assert target["receive_id"] == "oc_group"
+
+
+def test_normalize_post_message_only_image_without_mention_is_accepted() -> None:
+    """群聊 post 消息仅含图片且未 @机器人,应被接受(image 消息天然不携带 mentions)。"""
+    content = {
+        "zh_cn": {
+            "content": [[{"tag": "img", "image_key": "img_v3_post_2"}]],
+        }
+    }
+    event = _group_post_event(content)
+    result = _normalize_event(event, bot_open_id="ou_bot")
+    assert result is not None
+    inbound, _target = result
+    assert inbound.is_group is True
+    assert len(inbound.attachments) == 1
+    assert inbound.attachments[0].media_id == "img_v3_post_2"
+    assert inbound.text == ""
+
+
+def test_normalize_post_message_multiple_images() -> None:
+    """post 消息含多张图片时应全部提取。"""
+    content = {
+        "zh_cn": {
+            "content": [
+                [
+                    {"tag": "img", "image_key": "img_v3_multi_1"},
+                    {"tag": "img", "image_key": "img_v3_multi_2"},
+                ],
+                [{"tag": "text", "text": "两张图"}],
+            ],
+        }
+    }
+    mentions = [
+        SimpleNamespace(
+            id=SimpleNamespace(open_id="ou_bot"),
+            key="@_user_1",
+            mentioned_type="bot",
+        )
+    ]
+    event = _group_post_event(content, mentions=mentions)
+    result = _normalize_event(event, bot_open_id="ou_bot")
+    assert result is not None
+    inbound, _target = result
+    assert len(inbound.attachments) == 2
+    assert inbound.attachments[0].media_id == "img_v3_multi_1"
+    assert inbound.attachments[1].media_id == "img_v3_multi_2"
+    assert inbound.text == "两张图"
+
+
+def test_normalize_post_message_without_image_or_text_returns_none() -> None:
+    """post 消息既无图片也无文本时返回 None。"""
+    content = {
+        "zh_cn": {
+            "content": [[{"tag": "at", "user_id": "ou_bot"}]],
+        }
+    }
+    mentions = [
+        SimpleNamespace(
+            id=SimpleNamespace(open_id="ou_bot"),
+            key="@_user_1",
+            mentioned_type="bot",
+        )
+    ]
+    event = _group_post_event(content, mentions=mentions)
+    assert _normalize_event(event, bot_open_id="ou_bot") is None
+
+
+def test_normalize_post_message_en_us_locale() -> None:
+    """post 消息使用 en_us locale 也应正确解析。"""
+    content = {
+        "en_us": {
+            "content": [
+                [{"tag": "img", "image_key": "img_v3_en"}],
+                [{"tag": "text", "text": "check this"}],
+            ],
+        }
+    }
+    mentions = [
+        SimpleNamespace(
+            id=SimpleNamespace(open_id="ou_bot"),
+            key="@_user_1",
+            mentioned_type="bot",
+        )
+    ]
+    event = _group_post_event(content, mentions=mentions)
+    result = _normalize_event(event, bot_open_id="ou_bot")
+    assert result is not None
+    inbound, _target = result
+    assert len(inbound.attachments) == 1
+    assert inbound.attachments[0].media_id == "img_v3_en"
+    assert inbound.text == "check this"
+
+
+def test_normalize_post_message_without_locale_wrapper() -> None:
+    """post 消息 content 不带 locale 包裹(zh_cn/en_us)时也应正确解析。
+
+    部分飞书客户端在群聊中发送图片+@机器人时,content 结构为:
+    {"title":"","content":[[...]],"content_v2":[[...]]}
+    没有 zh_cn 外层包裹。
+    """
+    content = {
+        "title": "",
+        "content": [
+            [{"tag": "img", "image_key": "img_v3_nolocale"}],
+            [
+                {"tag": "at", "user_id": "@_user_1", "user_name": "StaffDeck渠道接入测试机器人"},
+                {"tag": "text", "text": " 查询假期余额"},
+            ],
+        ],
+        "content_v2": [
+            [{"tag": "img", "image_key": "img_v3_nolocale"}],
+            [
+                {"tag": "at", "user_id": "@_user_1"},
+                {"tag": "text", "text": " 查询假期余额"},
+            ],
+        ],
+    }
+    mentions = [
+        SimpleNamespace(
+            id=SimpleNamespace(open_id="ou_bot"),
+            key="@_user_1",
+            mentioned_type="bot",
+        )
+    ]
+    event = _group_post_event(content, mentions=mentions)
+    result = _normalize_event(event, bot_open_id="ou_bot")
+    assert result is not None
+    inbound, _target = result
+    assert len(inbound.attachments) == 1
+    assert inbound.attachments[0].media_id == "img_v3_nolocale"
+    assert inbound.text == "查询假期余额"

--- a/backend/tests/test_feishu_adapter.py
+++ b/backend/tests/test_feishu_adapter.py
@@ -481,3 +481,259 @@ def test_old_pending_retry_is_not_replayed_outside_uuid_window(tmp_path) -> None
         delivery = db.get(ChannelDelivery, delivery_id)
         assert delivery.status == "failed"
         assert delivery.last_error == "remote_state_unknown"
+
+
+def _p2p_event(*, message_type: str, content: dict, chat_type: str = "p2p"):
+    """构造飞书 P2P/群消息 event(用于 normalize image/file 测试)。"""
+    message = SimpleNamespace(
+        message_id="om_normalize",
+        chat_id="oc_chat" if chat_type == "group" else "",
+        chat_type=chat_type,
+        message_type=message_type,
+        content=json.dumps(content),
+        mentions=[],
+        thread_id="",
+        root_id="",
+    )
+    return SimpleNamespace(
+        header=SimpleNamespace(app_id="cli_app", tenant_key="tenant_key"),
+        event=SimpleNamespace(
+            message=message,
+            sender=SimpleNamespace(
+                sender_id=SimpleNamespace(open_id="ou_sender"),
+                sender_type="user",
+            ),
+        ),
+    )
+
+
+def _group_attachment_event(message_type: str, content: dict) -> object:
+    message = SimpleNamespace(
+        message_id="om_group_att",
+        chat_id="oc_group",
+        chat_type="group",
+        message_type=message_type,
+        content=json.dumps(content),
+        mentions=[
+            SimpleNamespace(
+                id=SimpleNamespace(open_id="ou_bot"),
+                key="@_user_1",
+                mentioned_type="bot",
+            )
+        ],
+        thread_id="",
+        root_id="",
+    )
+    return SimpleNamespace(
+        header=SimpleNamespace(app_id="cli_app", tenant_key="tenant_key"),
+        event=SimpleNamespace(
+            message=message,
+            sender=SimpleNamespace(
+                sender_id=SimpleNamespace(open_id="ou_sender"),
+                sender_type="user",
+            ),
+        ),
+    )
+
+
+def test_normalize_image_message_extracts_attachment() -> None:
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    event = _p2p_event(
+        message_type="image",
+        content={"image_key": "img_v3_001"},
+    )
+    result = _normalize_event(event, bot_open_id="ou_bot")
+    assert result is not None
+    inbound, _target = result
+    # 图片消息无文本,但附件存在所以不再被丢弃
+    assert inbound.text == ""
+    assert len(inbound.attachments) == 1
+    att = inbound.attachments[0]
+    assert isinstance(att, ChannelInboundAttachment)
+    assert att.media_id == "img_v3_001"
+    assert att.kind == "image"
+    assert att.filename == "img_v3_001.jpg"
+    assert att.content_type == "image/jpeg"
+    assert att.download_params == {
+        "file_key": "img_v3_001",
+        "type": "image",
+        "message_id": "om_normalize",
+    }
+
+
+def test_normalize_file_message_extracts_attachment_with_filename() -> None:
+    event = _p2p_event(
+        message_type="file",
+        content={"file_key": "file_v3_001", "file_name": "report.pdf"},
+    )
+    result = _normalize_event(event, bot_open_id="ou_bot")
+    assert result is not None
+    inbound, _target = result
+    assert inbound.text == ""
+    assert len(inbound.attachments) == 1
+    att = inbound.attachments[0]
+    assert att.media_id == "file_v3_001"
+    assert att.kind == "file"
+    assert att.filename == "report.pdf"
+    assert att.content_type == ""
+    assert att.download_params == {
+        "file_key": "file_v3_001",
+        "type": "file",
+        "message_id": "om_normalize",
+    }
+
+
+def test_normalize_text_message_has_empty_attachments() -> None:
+    """纯文本消息仍正常工作,attachments 为空列表。"""
+    event = _p2p_event(message_type="text", content={"text": "hello"})
+    result = _normalize_event(event, bot_open_id="ou_bot")
+    assert result is not None
+    inbound, _ = result
+    assert inbound.text == "hello"
+    assert inbound.attachments == []
+
+
+def test_normalize_image_without_image_key_returns_none() -> None:
+    """image 消息但 content 缺 image_key 时返回 None(无文本也无附件)。"""
+    event = _p2p_event(message_type="image", content={})
+    assert _normalize_event(event, bot_open_id="ou_bot") is None
+
+
+def test_normalize_group_attachment_requires_bot_mention() -> None:
+    """群聊 image/file 消息仍需 @ 机器人才能通过。"""
+    # 不带 @ 机器人
+    event_no_mention = _p2p_event(
+        message_type="image",
+        content={"image_key": "img_v3_002"},
+        chat_type="group",
+    )
+    assert _normalize_event(event_no_mention, bot_open_id="ou_bot") is None
+
+    # 带 @ 机器人
+    event = _group_attachment_event("image", {"image_key": "img_v3_003"})
+    result = _normalize_event(event, bot_open_id="ou_bot")
+    assert result is not None
+    inbound, target = result
+    assert inbound.is_group is True
+    assert len(inbound.attachments) == 1
+    assert inbound.attachments[0].media_id == "img_v3_003"
+    assert target["receive_id_type"] == "chat_id"
+    assert target["receive_id"] == "oc_group"
+
+
+def _binary_response(status: int, content: bytes, url: str) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=content,
+        request=httpx.Request("GET", url),
+    )
+
+
+def test_download_media_calls_resources_endpoint_with_bearer_token() -> None:
+    calls = []
+
+    def handler(url, kwargs):
+        calls.append((url, kwargs))
+        if "/auth/" in url:
+            return _response(200, {"code": 0, "tenant_access_token": "token-a", "expire": 7200}, url)
+        # 附件下载请求
+        assert url.endswith("/im/v1/messages/om_msg/resources/img_v3_001")
+        assert kwargs["params"] == {"type": "image"}
+        assert kwargs["headers"]["Authorization"] == "Bearer token-a"
+        return _binary_response(200, b"PNG-bytes", url)
+
+    def factory():
+        return FakeClient(handler)
+
+    adapter = FeishuAdapter(client_factory=factory)
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    att = ChannelInboundAttachment(
+        media_id="img_v3_001",
+        kind="image",
+        download_params={
+            "file_key": "img_v3_001",
+            "type": "image",
+            "message_id": "om_msg",
+        },
+    )
+    data = adapter.download_media(_binding(), att)
+    assert data == b"PNG-bytes"
+    # 确认只调用了一次资源下载
+    resource_calls = [c for c in calls if "/resources/" in c[0]]
+    assert len(resource_calls) == 1
+
+
+def test_download_media_missing_params_is_permanent_error() -> None:
+    adapter = FeishuAdapter(client_factory=lambda: FakeClient(lambda *_args: None))
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    att = ChannelInboundAttachment(
+        media_id="img_v3_001",
+        kind="image",
+        download_params={"file_key": "img_v3_001"},  # 缺 type 和 message_id
+    )
+    with pytest.raises(FeishuPermanentError, match="参数缺失"):
+        adapter.download_media(_binding(), att)
+
+
+def test_download_media_refreshes_token_on_401() -> None:
+    tokens = iter(["token-old", "token-new"])
+    resource_count = 0
+
+    def handler(url, kwargs):
+        if "/auth/" in url:
+            return _response(
+                200,
+                {"code": 0, "tenant_access_token": next(tokens), "expire": 7200},
+                url,
+            )
+        nonlocal resource_count
+        resource_count += 1
+        if resource_count == 1:
+            assert kwargs["headers"]["Authorization"] == "Bearer token-old"
+            return _binary_response(401, b"", url)
+        assert kwargs["headers"]["Authorization"] == "Bearer token-new"
+        return _binary_response(200, b"PNG-bytes", url)
+
+    def factory():
+        return FakeClient(handler)
+
+    adapter = FeishuAdapter(client_factory=factory)
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    att = ChannelInboundAttachment(
+        media_id="img_v3_001",
+        kind="image",
+        download_params={
+            "file_key": "img_v3_001",
+            "type": "image",
+            "message_id": "om_msg",
+        },
+    )
+    data = adapter.download_media(_binding(), att)
+    assert data == b"PNG-bytes"
+    assert resource_count == 2
+
+
+def test_download_media_5xx_is_transient() -> None:
+    def handler(url, _kwargs):
+        if "/auth/" in url:
+            return _response(200, {"code": 0, "tenant_access_token": "token", "expire": 7200}, url)
+        return _binary_response(503, b"", url)
+
+    adapter = FeishuAdapter(client_factory=lambda: FakeClient(handler))
+    from app.channels.adapters.base import ChannelInboundAttachment
+
+    att = ChannelInboundAttachment(
+        media_id="img_v3_001",
+        kind="image",
+        download_params={
+            "file_key": "img_v3_001",
+            "type": "image",
+            "message_id": "om_msg",
+        },
+    )
+    with pytest.raises(FeishuTransientError, match="暂时不可用"):
+        adapter.download_media(_binding(), att)

--- a/backend/tests/test_feishu_durable_inbox.py
+++ b/backend/tests/test_feishu_durable_inbox.py
@@ -7,9 +7,11 @@ from sqlalchemy import event, text
 from sqlalchemy.exc import OperationalError
 from sqlmodel import Session, SQLModel, create_engine, select
 
-from app.channels.adapters.base import ChannelInbound
+from app.channels.adapters.base import ChannelInbound, ChannelInboundAttachment
 from app.channels.service_feishu_inbox import (
     StageDisposition,
+    decode_replay_envelope,
+    encode_replay_envelope,
     feishu_account_key,
     feishu_identity_scope,
     stage_feishu_inbound,
@@ -504,3 +506,66 @@ def test_claim_is_released_when_claimed_loader_fails(monkeypatch, tmp_path) -> N
         event_row = db.get(ChannelInboundEvent, staged.event_pk)
         assert event_row.status == "received"
         assert event_row.processor_run_id is None
+
+
+def test_envelope_round_trips_attachments_as_dataclass() -> None:
+    inbound = ChannelInbound(
+        channel="feishu",
+        event_id="om_att_1",
+        from_user_id="ou_user_a",
+        to_user_id="ou_bot_a",
+        session_id="oc_chat_a",
+        group_id="",
+        context_token="om_message_a",
+        text="",
+        is_group=False,
+        raw={"event": {"message": {"message_id": "om_att_1"}}},
+        sender_name="User A",
+        account_scope="",
+        attachments=[
+            ChannelInboundAttachment(
+                media_id="img_v3_001",
+                kind="image",
+                filename="photo.png",
+                content_type="image/png",
+                size=1024,
+                download_params={
+                    "file_key": "img_v3_001",
+                    "type": "image",
+                    "message_id": "om_att_1",
+                },
+            ),
+            ChannelInboundAttachment(
+                media_id="file_v3_002",
+                kind="file",
+                filename="doc.pdf",
+                content_type="application/pdf",
+                size=2048,
+                download_params={
+                    "file_key": "file_v3_002",
+                    "type": "file",
+                    "message_id": "om_att_1",
+                },
+            ),
+        ],
+    )
+    envelope = encode_replay_envelope(inbound, app_id="cli_app_a", tenant_key="tenant_key_a")
+    decoded = decode_replay_envelope(envelope)
+    assert len(decoded.attachments) == 2
+    for att in decoded.attachments:
+        assert isinstance(att, ChannelInboundAttachment)
+    assert decoded.attachments[0].media_id == "img_v3_001"
+    assert decoded.attachments[0].kind == "image"
+    assert decoded.attachments[0].download_params["file_key"] == "img_v3_001"
+    assert decoded.attachments[0].download_params["message_id"] == "om_att_1"
+    assert decoded.attachments[1].media_id == "file_v3_002"
+    assert decoded.attachments[1].kind == "file"
+    assert decoded.attachments[1].filename == "doc.pdf"
+
+
+def test_envelope_round_trips_empty_attachments() -> None:
+    inbound = _inbound("om_no_att")
+    assert inbound.attachments == []
+    envelope = encode_replay_envelope(inbound, app_id="cli_app_a", tenant_key="tenant_key_a")
+    decoded = decode_replay_envelope(envelope)
+    assert decoded.attachments == []

--- a/frontend-enterprise/src/types/index.ts
+++ b/frontend-enterprise/src/types/index.ts
@@ -883,11 +883,20 @@ export type ChannelConversationRead = {
   updated_at: string;
 };
 
+export type ChannelConversationAttachmentRead = {
+  id?: string;
+  filename?: string;
+  content_type?: string;
+  size?: number;
+  kind?: string;
+};
+
 export type ChannelConversationMessageRead = {
   id: string;
   role: string;
   content: string;
   created_at: string;
+  attachments?: ChannelConversationAttachmentRead[];
 };
 
 export type ChannelBindCodeRead = {


### PR DESCRIPTION
Enable feishu and dingtalk users to send images and files that enter the existing Agent processing pipeline, consistent with web chat attachments.

Common infrastructure:
- Add ChannelInboundAttachment dataclass and ChannelInbound.attachments field
- Add attachment_bridge.inbound_attachments_to_chat() to download channel media and stage it via parse_chat_attachment + stage_chat_attachment
- Wire inbound_attachments_to_chat into service_intake.process_inbound with graceful degradation to text-only on failure
- Extend ChannelConversationMessageRead schema with attachments field
- Fix decode_replay_envelope in feishu/dingtalk/wecom inbox modules to restore ChannelInboundAttachment dataclasses from dict payloads during durable inbox replay (attachments were silently lost as list[dict])

Feishu:
- feishu_runtime._normalize_event: accept image/file message types, extract attachments via _extract_feishu_attachments
- FeishuAdapter.download_media: fetch image/file resources via message API with token refresh retry

DingTalk:
- normalize_dingtalk_message: accept picture/file msgtypes, extract attachments from raw.content.downloadCode (not raw.picture, matching actual SDK payload)
- DingTalkAdapter.download_media: two-step download via correct API path /robot/messageFiles/download (not /robot/messageCenter/file/download)

Tests: 30 new tests covering bridge, normalize, download_media, durable inbox envelope round-trip, and intake degradation. 473 channel tests pass.