### PR TITLE
fix(knowledge): 图谱可视化回调参数补类型，修复 TS7006 构建失败

### DIFF
--- a/frontend-enterprise/src/components/knowledge/KnowledgeGraphVisualization.tsx
+++ b/frontend-enterprise/src/components/knowledge/KnowledgeGraphVisualization.tsx
@@ -1,4 +1,4 @@
-import cytoscape, { type Core, type ElementDefinition, type LayoutOptions } from 'cytoscape';
+import cytoscape, { type Core, type EdgeSingular, type ElementDefinition, type EventObject, type LayoutOptions, type NodeSingular } from 'cytoscape';
 import {
   ArrowDownLeft,
   ArrowUpRight,
@@ -569,8 +569,8 @@ const GraphCanvas = forwardRef<GraphCanvasHandle, {
       minZoom: 0.2,
       maxZoom: 3,
     });
-    cy.on('tap', 'node', (event) => onSelectNode(event.target.id()));
-    cy.on('tap', (event) => {
+    cy.on('tap', 'node', (event: EventObject) => onSelectNode(String(event.target.id())));
+    cy.on('tap', (event: EventObject) => {
       if (event.target === cy) onSelectNode(null);
     });
     cy.on('zoom', () => updateSemanticLabels(cy));
@@ -594,14 +594,14 @@ const GraphCanvas = forwardRef<GraphCanvasHandle, {
     if (!cy) return;
     cy.elements().removeClass('is-dimmed is-related is-selected');
     const selected = selectedNodeId ? cy.getElementById(selectedNodeId) : cy.collection();
-    const matchingNodes = cy.nodes().filter((node) => {
+    const matchingNodes = cy.nodes().filter((node: NodeSingular) => {
       const graphNode = model.nodeById.get(node.id());
       if (!graphNode) return false;
       const matchesType = selectedTypes.length === 0 || selectedTypes.includes(graphNode.concept.concept_type);
       return matchesType && knowledgeConceptMatches(graphNode.concept, query);
     });
     cy.nodes().difference(matchingNodes).addClass('is-dimmed');
-    cy.edges().forEach((edge) => {
+    cy.edges().forEach((edge: EdgeSingular) => {
       if (edge.source().hasClass('is-dimmed') || edge.target().hasClass('is-dimmed')) edge.addClass('is-dimmed');
     });
     if (selected.length) {
@@ -829,7 +829,7 @@ function layoutOptions(layout: GraphLayout, animate: boolean): LayoutOptions {
 
 function updateSemanticLabels(cy: Core) {
   const lowZoom = cy.zoom() < 0.72;
-  cy.nodes().forEach((node) => {
+  cy.nodes().forEach((node: NodeSingular) => {
     const keepLabel = !lowZoom || Boolean(node.data('hub')) || node.hasClass('is-selected');
     node.toggleClass('label-hidden', !keepLabel);
   });


### PR DESCRIPTION
## 问题

`KnowledgeGraphVisualization.tsx` 的 cytoscape 回调参数缺少类型标注，严格 tsc 下报 TS7006(implicit any)，导致**纯净 main 上 `npm run build` 直接失败**:

- `cy.nodes().forEach((node) => ...)`(832 行）
- `cy.nodes().filter((node) => ...)`(597 行）
- `cy.edges().forEach((edge) => ...)`(604 行）
- `cy.on('tap', ...)` 两处（573 行等）

## 修复

按 cytoscape 官方类型标注：`NodeSingular` / `EdgeSingular` / `EventObject`（从 cytoscape 包导入类型，非 `any`)。

## 验证

- 修复前：纯净 main worktree 同样报这 5 处 TS7006;
- 修复后：`npm run build` 通过（仅 chunk 体积提示）。