### PR TITLE
feat(channels): 飞书渠道协作者管理与启停

### DIFF
--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -40,6 +40,7 @@ from app.channels.schema import (
     ChannelBindingManagerCreate,
     ChannelBindingManagerRead,
     ChannelBindingRead,
+    ChannelIdentityBindCodeCreate,
     ChannelConversationAttachmentRead,
     ChannelConversationMessageRead,
     ChannelConversationPage,
@@ -419,17 +420,7 @@ def _generate_bind_code() -> str:
     return f"{secrets.randbelow(900000) + 100000}"
 
 
-@router.post("/bind-code", response_model=ChannelBindCodeRead)
-def create_bind_code(
-    tenant_id: str = Query(...),
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_session),
-) -> ChannelBindCodeRead:
-    """为当前用户生成渠道身份绑定码(6 位数字,10 分钟有效,旧码作废)。"""
-    ensure_current_user_tenant(tenant_id, current_user)
-    if not _check_bind_code_rate(current_user.id):
-        raise HTTPException(status_code=429, detail="绑定码生成过于频繁，请稍后再试")
-    user_id = current_user.id
+def _issue_bind_code(db: Session, tenant_id: str, user_id: str) -> ChannelBindCodeRead:
     for _attempt in range(10):
         now = utc_now()
         record = db.exec(
@@ -458,6 +449,41 @@ def create_bind_code(
             continue
         return ChannelBindCodeRead(code=record.code, expires_at=record.expires_at.isoformat())
     raise HTTPException(status_code=409, detail="绑定码生成冲突，请重试")
+
+
+@router.post("/bind-code", response_model=ChannelBindCodeRead)
+def create_bind_code(
+    tenant_id: str = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_session),
+) -> ChannelBindCodeRead:
+    """为当前用户生成渠道身份绑定码(6 位数字,10 分钟有效,旧码作废)。"""
+    ensure_current_user_tenant(tenant_id, current_user)
+    if not _check_bind_code_rate(current_user.id):
+        raise HTTPException(status_code=429, detail="绑定码生成过于频繁，请稍后再试")
+    return _issue_bind_code(db, tenant_id, current_user.id)
+
+
+@router.post("/{binding_id}/identity-bind-code", response_model=ChannelBindCodeRead)
+def create_identity_bind_code(
+    binding_id: str,
+    request: ChannelIdentityBindCodeCreate,
+    tenant_id: str = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_session),
+) -> ChannelBindCodeRead:
+    """为内部成员生成身份绑定邀请；成员仍须用自己的渠道账号发送绑定指令。"""
+    ensure_current_user_tenant(tenant_id, current_user)
+    binding = _get_binding(db, tenant_id, binding_id)
+    _ensure_binding_manager(db, tenant_id, binding, current_user, action=_MANAGER_ACTION_AGENTS)
+    target = db.get(User, request.user_id)
+    if not target or target.tenant_id != tenant_id or target.source != "web":
+        raise HTTPException(status_code=400, detail="身份绑定对象必须是当前租户的内部成员")
+    if binding.channel == "feishu" and not binding.identity_scope_key:
+        raise HTTPException(status_code=409, detail="请先完成飞书应用接入，再邀请成员绑定身份")
+    if not _check_bind_code_rate(current_user.id):
+        raise HTTPException(status_code=429, detail="绑定码生成过于频繁，请稍后再试")
+    return _issue_bind_code(db, tenant_id, target.id)
 
 
 @router.get("/my-identity-bindings", response_model=list[MyIdentityBindingRead])

--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -575,6 +575,21 @@ def update_channel_binding_agents(
                 status_code=400,
                 detail="默认人工处理人必须是当前租户的内部成员",
             )
+        if binding.channel == "feishu":
+            reachable = db.exec(
+                select(ChannelIdentity).where(
+                    ChannelIdentity.tenant_id == tenant_id,
+                    ChannelIdentity.channel == "feishu",
+                    ChannelIdentity.external_account_scope == binding.identity_scope_key,
+                    ChannelIdentity.staffdeck_user_id == handoff_assignee,
+                    ~ChannelIdentity.external_user_id.startswith("group:"),
+                )
+            ).first()
+            if not reachable:
+                raise HTTPException(
+                    status_code=400,
+                    detail="默认人工处理人必须已绑定当前飞书账号",
+                )
     default_agent_id: str | None = None
     if request.agents is not None:
         if not request.agents:

--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -11,7 +11,7 @@ from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import Response as FastAPIResponse
-from sqlalchemy import case, text, update
+from sqlalchemy import case, or_, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
@@ -37,6 +37,8 @@ from app.channels.schema import (
     ChannelBindingAgentRead,
     ChannelBindingAgentsUpdate,
     ChannelBindingCreate,
+    ChannelBindingManagerCreate,
+    ChannelBindingManagerRead,
     ChannelBindingRead,
     ChannelConversationAttachmentRead,
     ChannelConversationMessageRead,
@@ -75,6 +77,7 @@ from app.db.models import (
     ChannelBindCode,
     ChannelBinding,
     ChannelBindingAgent,
+    ChannelBindingManager,
     ChannelConvState,
     ChannelDelivery,
     ChannelIdentity,
@@ -200,10 +203,44 @@ def _get_binding(db: Session, tenant_id: str, binding_id: str) -> ChannelBinding
     return binding
 
 
-def _ensure_binding_manager(db: Session, tenant_id: str, binding: ChannelBinding, current_user: User) -> None:
-    """渠道绑定管理权限:仅 admin 或绑定创建者;不随默认员工(binding.agent_id)漂移。"""
+_MANAGER_ACTION_CREDENTIALS = "manage_credentials"
+_MANAGER_ACTION_AGENTS = "manage_agents"
+_MANAGER_ACTION_TOGGLE_STATUS = "toggle_status"
+# 协作者可执行的 action 集合;delete/manage_managers 不在此列,仅创建者+admin 可为
+_COLLABORATOR_ACTIONS = frozenset(
+    {_MANAGER_ACTION_CREDENTIALS, _MANAGER_ACTION_AGENTS, _MANAGER_ACTION_TOGGLE_STATUS}
+)
+
+
+def _is_active_collaborator(db: Session, binding: ChannelBinding, user: User) -> bool:
+    """该用户是否为该绑定的有效协作者(revoked_at 为空)。"""
+    row = db.exec(
+        select(ChannelBindingManager).where(
+            ChannelBindingManager.binding_id == binding.id,
+            ChannelBindingManager.user_id == user.id,
+            ChannelBindingManager.revoked_at.is_(None),
+        )
+    ).first()
+    return row is not None
+
+
+def _ensure_binding_manager(
+    db: Session,
+    tenant_id: str,
+    binding: ChannelBinding,
+    current_user: User,
+    action: str | None = None,
+) -> None:
+    """渠道绑定管理权限。
+
+    admin/创建者全权;协作者仅可在 _COLLABORATOR_ACTIONS 范围内操作
+    (凭证/挂载/启停)。删除渠道、管理协作者名单仅限创建者+admin。
+    不随默认员工(binding.agent_id)漂移。
+    """
     ensure_current_user_tenant(tenant_id, current_user)
     if is_admin_user(current_user) or binding.created_by_user_id == current_user.id:
+        return
+    if action in _COLLABORATOR_ACTIONS and _is_active_collaborator(db, binding, current_user):
         return
     raise HTTPException(status_code=403, detail="Only the creator or administrator can manage this channel binding")
 
@@ -281,10 +318,20 @@ def list_channel_bindings(
     if agent_id:
         statement = statement.where(ChannelBinding.agent_id == agent_id)
     elif not is_admin_user(current_user):
-        # 渠道绑定是租户级资源:admin 全量可见,普通成员只见自己创建的
-        statement = statement.where(ChannelBinding.created_by_user_id == current_user.id)
+        # 渠道绑定是租户级资源:admin 全量可见,普通成员可见自己创建的或被授权协管的
+        managed_ids = select(ChannelBindingManager.binding_id).where(
+            ChannelBindingManager.tenant_id == tenant_id,
+            ChannelBindingManager.user_id == current_user.id,
+            ChannelBindingManager.revoked_at.is_(None),
+        )
+        statement = statement.where(
+            or_(
+                ChannelBinding.created_by_user_id == current_user.id,
+                ChannelBinding.id.in_(managed_ids),
+            )
+        )
     rows = db.exec(statement.order_by(ChannelBinding.created_at)).all()
-    return [channel_binding_read(db, row) for row in rows]
+    return [channel_binding_read(db, row, current_user) for row in rows]
 
 
 @router.post("", response_model=ChannelBindingRead)
@@ -340,7 +387,7 @@ def create_channel_binding(
         )
     db.commit()
     db.refresh(binding)
-    return channel_binding_read(db, binding)
+    return channel_binding_read(db, binding, current_user)
 
 
 BIND_CODE_TTL_MINUTES = 10
@@ -495,7 +542,7 @@ def list_channel_binding_agents(
 ) -> list[ChannelBindingAgentRead]:
     ensure_current_user_tenant(tenant_id, current_user)
     binding = _get_binding(db, tenant_id, binding_id)
-    _ensure_binding_manager(db, tenant_id, binding, current_user)
+    _ensure_binding_manager(db, tenant_id, binding, current_user, action=_MANAGER_ACTION_AGENTS)
     return channel_binding_agents_read(db, binding)
 
 
@@ -509,7 +556,7 @@ def update_channel_binding_agents(
 ) -> ChannelBindingRead:
     ensure_current_user_tenant(tenant_id, current_user)
     binding = _get_binding(db, tenant_id, binding_id)
-    _ensure_binding_manager(db, tenant_id, binding, current_user)
+    _ensure_binding_manager(db, tenant_id, binding, current_user, action=_MANAGER_ACTION_AGENTS)
     if (
         request.agents is None
         and request.auto_route is None
@@ -586,7 +633,7 @@ def update_channel_binding_agents(
             db.commit()
         binding = _get_binding(db, tenant_id, binding_id)
         db.refresh(binding)
-        return channel_binding_read(db, binding)
+        return channel_binding_read(db, binding, current_user)
 
 
 @router.delete("/{binding_id}", status_code=204)
@@ -691,6 +738,179 @@ def delete_channel_binding(
     return Response(status_code=204)
 
 
+def _user_display_name(db: Session, user_id: str, tenant_id: str) -> str | None:
+    """租户内用户展示名;用户不存在或不属于该租户时返回 None。"""
+    user = db.get(User, user_id)
+    if not user or user.tenant_id != tenant_id:
+        return None
+    return user.display_name or user.username
+
+
+@router.get("/{binding_id}/managers", response_model=list[ChannelBindingManagerRead])
+def list_channel_binding_managers(
+    binding_id: str,
+    tenant_id: str = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_session),
+) -> list[ChannelBindingManagerRead]:
+    """列出渠道协作者(仅创建者+admin 可见协作者名单)。"""
+    ensure_current_user_tenant(tenant_id, current_user)
+    binding = _get_binding(db, tenant_id, binding_id)
+    _ensure_binding_manager(db, tenant_id, binding, current_user)
+    rows = db.exec(
+        select(ChannelBindingManager)
+        .where(
+            ChannelBindingManager.binding_id == binding.id,
+            ChannelBindingManager.revoked_at.is_(None),
+        )
+        .order_by(ChannelBindingManager.granted_at)
+    ).all()
+    return [
+        ChannelBindingManagerRead(
+            user_id=row.user_id,
+            name=_user_display_name(db, row.user_id, tenant_id),
+            granted_at=row.granted_at.isoformat(),
+            granted_by_user_id=row.granted_by_user_id,
+            granted_by_name=_user_display_name(db, row.granted_by_user_id, tenant_id),
+        )
+        for row in rows
+    ]
+
+
+@router.post(
+    "/{binding_id}/managers",
+    response_model=ChannelBindingManagerRead,
+    status_code=201,
+)
+def add_channel_binding_manager(
+    binding_id: str,
+    request: ChannelBindingManagerCreate,
+    tenant_id: str = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_session),
+) -> ChannelBindingManagerRead:
+    """添加协作者(仅创建者+admin)。同一(binding,user)仅一行,已撤销则复活。"""
+    ensure_current_user_tenant(tenant_id, current_user)
+    binding = _get_binding(db, tenant_id, binding_id)
+    _ensure_binding_manager(db, tenant_id, binding, current_user)
+    target = db.get(User, request.user_id)
+    if not target or target.tenant_id != tenant_id or target.source != "web":
+        raise HTTPException(status_code=400, detail="协作者必须是当前租户的内部成员")
+    if target.id == binding.created_by_user_id:
+        raise HTTPException(status_code=400, detail="创建者已是该渠道拥有者,无需添加")
+    if is_admin_user(target):
+        raise HTTPException(status_code=400, detail="管理员默认拥有全部渠道权限,无需添加")
+    existing = db.exec(
+        select(ChannelBindingManager).where(
+            ChannelBindingManager.binding_id == binding.id,
+            ChannelBindingManager.user_id == target.id,
+        )
+    ).first()
+    if existing and existing.revoked_at is None:
+        raise HTTPException(status_code=409, detail="该用户已是协作者")
+    try:
+        if existing:
+            existing.revoked_at = None
+            existing.granted_by_user_id = current_user.id
+            existing.granted_at = utc_now()
+            existing.tenant_id = tenant_id
+            manager = existing
+        else:
+            manager = ChannelBindingManager(
+                tenant_id=tenant_id,
+                binding_id=binding.id,
+                user_id=target.id,
+                granted_by_user_id=current_user.id,
+            )
+        db.add(manager)
+        db.commit()
+        db.refresh(manager)
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="该用户已是协作者") from exc
+    return ChannelBindingManagerRead(
+        user_id=manager.user_id,
+        name=_user_display_name(db, manager.user_id, tenant_id),
+        granted_at=manager.granted_at.isoformat(),
+        granted_by_user_id=manager.granted_by_user_id,
+        granted_by_name=_user_display_name(db, manager.granted_by_user_id, tenant_id),
+    )
+
+
+@router.delete("/{binding_id}/managers/{user_id}", status_code=204)
+def remove_channel_binding_manager(
+    binding_id: str,
+    user_id: str,
+    tenant_id: str = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_session),
+) -> Response:
+    """移除协作者(仅创建者+admin):软撤销(revoked_at),保留审计。"""
+    ensure_current_user_tenant(tenant_id, current_user)
+    binding = _get_binding(db, tenant_id, binding_id)
+    _ensure_binding_manager(db, tenant_id, binding, current_user)
+    row = db.exec(
+        select(ChannelBindingManager).where(
+            ChannelBindingManager.binding_id == binding.id,
+            ChannelBindingManager.user_id == user_id,
+            ChannelBindingManager.revoked_at.is_(None),
+        )
+    ).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="协作者不存在或已移除")
+    row.revoked_at = utc_now()
+    db.add(row)
+    db.commit()
+    return Response(status_code=204)
+
+
+@router.post("/{binding_id}/toggle-status", response_model=ChannelBindingRead)
+def toggle_channel_binding_status(
+    binding_id: str,
+    tenant_id: str = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_session),
+) -> ChannelBindingRead:
+    """切换渠道启停(创建者/admin/协作者可)。
+
+    active -> disabled(停用,quiesce 长连接);
+    disabled/pending/expired -> active(启用,有凭证则恢复长连接)。
+    """
+    ensure_current_user_tenant(tenant_id, current_user)
+    binding = _get_binding(db, tenant_id, binding_id)
+    _ensure_binding_manager(
+        db, tenant_id, binding, current_user, action=_MANAGER_ACTION_TOGGLE_STATUS
+    )
+    target_status = "disabled" if binding.status == "active" else "active"
+    expected_revision = binding.config_revision
+    channel = binding.channel
+    should_run = bool(binding.status == "active" and binding.credentials_enc)
+    db.rollback()
+    with binding_lifecycle_lock(binding_id):
+        binding = _get_binding(db, tenant_id, binding_id)
+        _ensure_revision(binding, expected_revision)
+        if target_status == "disabled":
+            _quiesce_binding_or_409(channel, binding_id, should_run=should_run)
+        try:
+            binding = _get_binding(db, tenant_id, binding_id)
+            _ensure_revision(binding, expected_revision)
+            binding.status = target_status
+            binding.updated_at = utc_now()
+            db.add(binding)
+            db.commit()
+            db.refresh(binding)
+        except Exception:
+            db.rollback()
+            if target_status == "disabled":
+                _resume_binding(channel, binding_id, start=should_run)
+            raise
+        if target_status == "disabled":
+            _resume_binding(channel, binding_id, start=False)
+        elif binding.credentials_enc:
+            _resume_binding(channel, binding_id, start=True)
+    return channel_binding_read(db, binding, current_user)
+
+
 @router.post("/{binding_id}/wechat/qrcode", response_model=ChannelQRCodeRead)
 def create_wechat_qrcode(
     binding_id: str,
@@ -700,7 +920,7 @@ def create_wechat_qrcode(
 ) -> ChannelQRCodeRead:
     ensure_current_user_tenant(tenant_id, current_user)
     binding = _get_binding(db, tenant_id, binding_id)
-    _ensure_binding_manager(db, tenant_id, binding, current_user)
+    _ensure_binding_manager(db, tenant_id, binding, current_user, action=_MANAGER_ACTION_CREDENTIALS)
     # 官方协议:local_token_list 带上本地已有 bot_token(最多 10 个),支持旧凭证续绑
     local_tokens: list[str] = []
     if binding.credentials_enc:
@@ -780,7 +1000,7 @@ def poll_wechat_qrcode_status(
 ) -> ChannelQRCodeStatusRead:
     ensure_current_user_tenant(tenant_id, current_user)
     binding = _get_binding(db, tenant_id, binding_id)
-    _ensure_binding_manager(db, tenant_id, binding, current_user)
+    _ensure_binding_manager(db, tenant_id, binding, current_user, action=_MANAGER_ACTION_CREDENTIALS)
     redirect_baseurl = str((binding.config_json or {}).get("qrcode_redirect_baseurl") or "").strip()
     has_credentials = bool(binding.credentials_enc)
     db.rollback()
@@ -820,7 +1040,7 @@ def poll_wechat_qrcode_status(
         if has_credentials:
             binding = _get_binding(db, tenant_id, binding_id)
             binding = _activate_binding_with_existing_credentials(db, binding)
-            return ChannelQRCodeStatusRead(status="confirmed", binding=channel_binding_read(db, binding))
+            return ChannelQRCodeStatusRead(status="confirmed", binding=channel_binding_read(db, binding, current_user))
         return ChannelQRCodeStatusRead(status=status)
     if status != "confirmed":
         # wait/scaned/expired/need_verifycode/verify_code_blocked 等原样透传
@@ -891,7 +1111,7 @@ def poll_wechat_qrcode_status(
             _resume_binding(channel, binding_id, start=should_run)
             raise
         _resume_binding(channel, binding_id, start=True)
-    return ChannelQRCodeStatusRead(status=status, binding=channel_binding_read(db, binding))
+    return ChannelQRCodeStatusRead(status=status, binding=channel_binding_read(db, binding, current_user))
 
 
 @router.post("/{binding_id}/wecom/credentials", response_model=ChannelBindingRead)
@@ -904,7 +1124,7 @@ def save_wecom_credentials(
     """保存企微智能机器人凭证(bot_id + secret),激活绑定并拉起长连接。"""
     ensure_current_user_tenant(request.tenant_id, current_user)
     binding = _get_binding(db, request.tenant_id, binding_id)
-    _ensure_binding_manager(db, request.tenant_id, binding, current_user)
+    _ensure_binding_manager(db, request.tenant_id, binding, current_user, action=_MANAGER_ACTION_CREDENTIALS)
     if binding.channel != "wecom":
         raise HTTPException(status_code=400, detail="该绑定不是企业微信渠道")
     bot_id = request.bot_id.strip()
@@ -994,7 +1214,7 @@ def save_wecom_credentials(
             _resume_binding(channel, binding_id, start=should_run)
             raise
         _resume_binding(channel, binding_id, start=True)
-    return channel_binding_read(db, binding)
+    return channel_binding_read(db, binding, current_user)
 
 
 @router.post("/{binding_id}/feishu/credentials", response_model=ChannelBindingRead)
@@ -1007,7 +1227,7 @@ def save_feishu_credentials(
     """Validate and save Feishu app credentials, then start its long connection."""
     ensure_current_user_tenant(request.tenant_id, current_user)
     binding = _get_binding(db, request.tenant_id, binding_id)
-    _ensure_binding_manager(db, request.tenant_id, binding, current_user)
+    _ensure_binding_manager(db, request.tenant_id, binding, current_user, action=_MANAGER_ACTION_CREDENTIALS)
     if binding.channel != "feishu":
         raise HTTPException(status_code=400, detail="该绑定不是飞书渠道")
     app_id = request.app_id.strip()
@@ -1076,7 +1296,7 @@ def save_feishu_credentials(
             _resume_binding(channel, binding_id, start=should_run)
             raise
         _resume_binding(channel, binding_id, start=True)
-    return channel_binding_read(db, binding)
+    return channel_binding_read(db, binding, current_user)
 
 
 @router.post("/{binding_id}/dingtalk/credentials", response_model=ChannelBindingRead)
@@ -1089,7 +1309,7 @@ def save_dingtalk_credentials(
     """Validate and save DingTalk Stream credentials, then start its connector."""
     ensure_current_user_tenant(request.tenant_id, current_user)
     binding = _get_binding(db, request.tenant_id, binding_id)
-    _ensure_binding_manager(db, request.tenant_id, binding, current_user)
+    _ensure_binding_manager(db, request.tenant_id, binding, current_user, action=_MANAGER_ACTION_CREDENTIALS)
     if binding.channel != "dingtalk":
         raise HTTPException(status_code=400, detail="该绑定不是钉钉渠道")
     client_id = request.client_id.strip()
@@ -1149,7 +1369,7 @@ def save_dingtalk_credentials(
             _resume_binding(binding.channel, binding_id, start=should_run)
             raise
         _resume_binding(binding.channel, binding_id, start=True)
-    return channel_binding_read(db, binding)
+    return channel_binding_read(db, binding, current_user)
 
 
 @router.get("/delivery-audit", response_model=ChannelDeliveryPage)

--- a/backend/app/channels/schema.py
+++ b/backend/app/channels/schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from pydantic import BaseModel
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.db.models import ChannelBinding, ChannelDelivery, Team, User
 
@@ -69,6 +69,8 @@ class ChannelBindingRead(BaseModel):
     default_handoff_assignee_user_id: Optional[str] = None
     default_handoff_assignee_name: Optional[str] = None
     identity_scope_key: Optional[str] = None
+    # 当前请求者对该绑定的管理角色:admin/owner/collaborator;无管理关系时为 None
+    my_role: Optional[str] = None
     created_at: str
     updated_at: str
 
@@ -86,6 +88,18 @@ class ChannelQRCodeStatusRead(BaseModel):
 class ChannelBindCodeRead(BaseModel):
     code: str
     expires_at: str
+
+
+class ChannelBindingManagerCreate(BaseModel):
+    user_id: str
+
+
+class ChannelBindingManagerRead(BaseModel):
+    user_id: str
+    name: Optional[str] = None
+    granted_at: str
+    granted_by_user_id: Optional[str] = None
+    granted_by_name: Optional[str] = None
 
 
 class MyIdentityBindingRead(BaseModel):
@@ -246,7 +260,32 @@ def _default_handoff_assignee_name(db: Session, binding: ChannelBinding) -> Opti
     return user.display_name or user.username
 
 
-def channel_binding_read(db: Session, binding: ChannelBinding) -> ChannelBindingRead:
+def channel_binding_my_role(
+    db: Session, binding: ChannelBinding, current_user: Optional[User]
+) -> Optional[str]:
+    """当前用户对该绑定的管理角色:admin/owner/collaborator;无管理关系时返回 None。"""
+    if current_user is None:
+        return None
+    from app.db.models import ChannelBindingManager
+    from app.security.permissions import is_admin_user
+
+    if is_admin_user(current_user):
+        return "admin"
+    if binding.created_by_user_id == current_user.id:
+        return "owner"
+    row = db.exec(
+        select(ChannelBindingManager).where(
+            ChannelBindingManager.binding_id == binding.id,
+            ChannelBindingManager.user_id == current_user.id,
+            ChannelBindingManager.revoked_at.is_(None),
+        )
+    ).first()
+    return "collaborator" if row else None
+
+
+def channel_binding_read(
+    db: Session, binding: ChannelBinding, current_user: Optional[User] = None
+) -> ChannelBindingRead:
     config = dict(binding.config_json or {})
     bound_at = config.get("bound_at")
     team_name: Optional[str] = None
@@ -283,6 +322,7 @@ def channel_binding_read(db: Session, binding: ChannelBinding) -> ChannelBinding
         ),
         default_handoff_assignee_name=_default_handoff_assignee_name(db, binding),
         identity_scope_key=binding.identity_scope_key,
+        my_role=channel_binding_my_role(db, binding, current_user),
         created_at=binding.created_at.isoformat(),
         updated_at=binding.updated_at.isoformat(),
     )

--- a/backend/app/channels/schema.py
+++ b/backend/app/channels/schema.py
@@ -90,6 +90,10 @@ class ChannelBindCodeRead(BaseModel):
     expires_at: str
 
 
+class ChannelIdentityBindCodeCreate(BaseModel):
+    user_id: str
+
+
 class ChannelBindingManagerCreate(BaseModel):
     user_id: str
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -818,6 +818,28 @@ class ChannelBindingAgent(SQLModel, table=True):
     created_at: datetime = Field(default_factory=utc_now)
 
 
+class ChannelBindingManager(SQLModel, table=True):
+    """渠道绑定协作者:创建者/admin 显式授权的非创建者,可凭证/挂载/启停但不能删除。
+
+    同一 (binding, user) 仅一行;移除即软撤销(revoked_at),重新添加复活该行,
+    保留最近一次授权/撤销记录用于审计。删除渠道绑定级联清空协作者行。
+    """
+
+    __tablename__ = "channel_binding_managers"
+    __table_args__ = (
+        UniqueConstraint("binding_id", "user_id", name="uq_channel_binding_manager"),
+        Index("ix_channel_binding_managers_tenant_user", "tenant_id", "user_id"),
+    )
+
+    id: str = Field(default_factory=lambda: new_id("chbm"), primary_key=True)
+    tenant_id: str = Field(index=True)
+    binding_id: str = Field(index=True)
+    user_id: str = Field(index=True)
+    granted_by_user_id: str
+    granted_at: datetime = Field(default_factory=utc_now)
+    revoked_at: Optional[datetime] = None
+
+
 class ChannelConvState(SQLModel, table=True):
     """路由指针：每个 (binding, external_conv_id) 会话的当前员工。"""
 

--- a/backend/tests/test_channel_api.py
+++ b/backend/tests/test_channel_api.py
@@ -11,6 +11,7 @@ from app.db import get_session
 from app.db.models import (
     AgentProfile,
     ChannelBinding,
+    ChannelIdentity,
     ChannelDelivery,
     ChannelInboundEvent,
     Message,
@@ -1277,6 +1278,52 @@ def test_put_binding_default_handoff_assignee_rejects_channel_customer() -> None
     )
 
     assert response.status_code == 400
+
+
+def test_put_feishu_default_handoff_assignee_requires_bound_identity() -> None:
+    engine = _test_engine()
+    users = _seed_users(engine)
+    with Session(engine) as db:
+        binding = ChannelBinding(
+            tenant_id="tenant_demo",
+            agent_id="agent_1",
+            channel="feishu",
+            status="active",
+            identity_scope_key="cli_feishu:tenant_a",
+            created_by_user_id="user_owner",
+        )
+        db.add(binding)
+        db.commit()
+        db.refresh(binding)
+        binding_id = binding.id
+    client = _make_client(engine)
+
+    unbound = client.put(
+        f"/api/enterprise/channels/{binding_id}?tenant_id=tenant_demo",
+        json={"default_handoff_assignee_user_id": "user_owner"},
+        headers=_auth(users["owner"]),
+    )
+    assert unbound.status_code == 400
+
+    with Session(engine) as db:
+        db.add(
+            ChannelIdentity(
+                tenant_id="tenant_demo",
+                channel="feishu",
+                external_account_scope="cli_feishu:tenant_a",
+                external_user_id="ou_owner",
+                display_name="Owner",
+                staffdeck_user_id="user_owner",
+            )
+        )
+        db.commit()
+
+    reachable = client.put(
+        f"/api/enterprise/channels/{binding_id}?tenant_id=tenant_demo",
+        json={"default_handoff_assignee_user_id": "user_owner"},
+        headers=_auth(users["owner"]),
+    )
+    assert reachable.status_code == 200
 
 
 def test_put_binding_default_handoff_assignee_unchanged_by_default() -> None:

--- a/backend/tests/test_channel_managers.py
+++ b/backend/tests/test_channel_managers.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.pool import StaticPool
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 
 import app.api.channels as channels_api
 from app.db import get_session
 from app.db.models import (
     AgentProfile,
     ChannelBinding,
+    ChannelBindCode,
     ChannelBindingManager,
     Tenant,
     User,
@@ -164,6 +165,40 @@ def test_collaborator_can_toggle_status(monkeypatch) -> None:
     )
     assert enable.status_code == 200, enable.text
     assert enable.json()["status"] == "active"
+
+
+def test_manager_can_invite_internal_user_to_bind_identity() -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    binding_id = _seed_binding(engine)
+    with Session(engine) as db:
+        binding = db.get(ChannelBinding, binding_id)
+        binding.identity_scope_key = "cli_feishu:tenant_a"
+        db.add(binding)
+        db.commit()
+
+    invited = client.post(
+        f"/api/enterprise/channels/{binding_id}/identity-bind-code",
+        params={"tenant_id": "tenant_demo"},
+        json={"user_id": "user_other"},
+        headers=_auth(users["owner"]),
+    )
+    assert invited.status_code == 200, invited.text
+    assert len(invited.json()["code"]) == 6
+    with Session(engine) as db:
+        record = db.exec(
+            select(ChannelBindCode).where(ChannelBindCode.user_id == "user_other")
+        ).one()
+        assert record.code == invited.json()["code"]
+
+    forbidden = client.post(
+        f"/api/enterprise/channels/{binding_id}/identity-bind-code",
+        params={"tenant_id": "tenant_demo"},
+        json={"user_id": "user_owner"},
+        headers=_auth(users["outsider"]),
+    )
+    assert forbidden.status_code == 403
 
 
 def test_collaborator_cannot_delete(monkeypatch) -> None:

--- a/backend/tests/test_channel_managers.py
+++ b/backend/tests/test_channel_managers.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+import app.api.channels as channels_api
+from app.db import get_session
+from app.db.models import (
+    AgentProfile,
+    ChannelBinding,
+    ChannelBindingManager,
+    Tenant,
+    User,
+)
+from app.security.auth import create_access_token
+
+
+def _engine():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def _client(engine) -> TestClient:
+    app = FastAPI()
+    app.include_router(channels_api.router)
+
+    def override_session():
+        with Session(engine) as db:
+            yield db
+
+    app.dependency_overrides[get_session] = override_session
+    return TestClient(app)
+
+
+def _seed(engine) -> dict[str, User]:
+    with Session(engine) as db:
+        db.add(Tenant(id="tenant_demo", name="Demo"))
+        owner = User(id="user_owner", tenant_id="tenant_demo", username="owner", password_hash="x")
+        other = User(id="user_other", tenant_id="tenant_demo", username="other", password_hash="x")
+        admin = User(id="user_admin", tenant_id="tenant_demo", username="admin", role="admin", password_hash="x")
+        outsider = User(id="user_outsider", tenant_id="tenant_demo", username="outsider", password_hash="x")
+        db.add(
+            AgentProfile(
+                id="agent_1",
+                tenant_id="tenant_demo",
+                name="客服员工",
+                is_overall=False,
+                metadata_json={"owner_user_id": owner.id},
+            )
+        )
+        db.add_all([owner, other, admin, outsider])
+        db.commit()
+        for u in (owner, other, admin, outsider):
+            db.refresh(u)
+            db.expunge(u)
+        return {"owner": owner, "other": other, "admin": admin, "outsider": outsider}
+
+
+def _auth(user: User) -> dict[str, str]:
+    return {"Authorization": f"Bearer {create_access_token(user)}"}
+
+
+def _seed_binding(
+    engine,
+    *,
+    channel: str = "feishu",
+    created_by: str = "user_owner",
+    status: str = "active",
+) -> str:
+    with Session(engine) as db:
+        binding = ChannelBinding(
+            tenant_id="tenant_demo",
+            agent_id="agent_1",
+            channel=channel,
+            status=status,
+            created_by_user_id=created_by,
+        )
+        db.add(binding)
+        db.commit()
+        return binding.id
+
+
+def _add_collaborator(engine, binding_id: str, user_id: str, *, granted_by: str = "user_owner") -> None:
+    with Session(engine) as db:
+        db.add(
+            ChannelBindingManager(
+                tenant_id="tenant_demo",
+                binding_id=binding_id,
+                user_id=user_id,
+                granted_by_user_id=granted_by,
+            )
+        )
+        db.commit()
+
+
+def test_collaborator_can_save_feishu_credentials(monkeypatch) -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    monkeypatch.setattr(channels_api, "channel_services_enabled", lambda: False)
+    monkeypatch.setattr(
+        channels_api,
+        "validate_feishu_credentials",
+        lambda app_id, secret: {"bot_open_id": "ou_bot", "bot_name": "StaffDeck Bot"},
+    )
+    binding_id = _seed_binding(engine, status="pending")
+    client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_other"},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["owner"]),
+    )
+    resp = client.post(
+        f"/api/enterprise/channels/{binding_id}/feishu/credentials",
+        json={"tenant_id": "tenant_demo", "app_id": "cli_1", "app_secret": "sec"},
+        headers=_auth(users["other"]),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "active"
+    assert resp.json()["my_role"] == "collaborator"
+
+
+def test_collaborator_can_manage_agents() -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    binding_id = _seed_binding(engine)
+    _add_collaborator(engine, binding_id, "user_other")
+    resp = client.put(
+        f"/api/enterprise/channels/{binding_id}",
+        json={"auto_route": False},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["other"]),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["auto_route"] is False
+
+
+def test_collaborator_can_toggle_status(monkeypatch) -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    monkeypatch.setattr(channels_api, "channel_services_enabled", lambda: False)
+    binding_id = _seed_binding(engine, status="active")
+    _add_collaborator(engine, binding_id, "user_other")
+    disable = client.post(
+        f"/api/enterprise/channels/{binding_id}/toggle-status",
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["other"]),
+    )
+    assert disable.status_code == 200, disable.text
+    assert disable.json()["status"] == "disabled"
+    enable = client.post(
+        f"/api/enterprise/channels/{binding_id}/toggle-status",
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["other"]),
+    )
+    assert enable.status_code == 200, enable.text
+    assert enable.json()["status"] == "active"
+
+
+def test_collaborator_cannot_delete(monkeypatch) -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    monkeypatch.setattr(channels_api, "channel_services_enabled", lambda: False)
+    binding_id = _seed_binding(engine, status="active")
+    _add_collaborator(engine, binding_id, "user_other")
+    resp = client.delete(
+        f"/api/enterprise/channels/{binding_id}",
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["other"]),
+    )
+    assert resp.status_code == 403
+
+
+def test_collaborator_cannot_manage_managers() -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    binding_id = _seed_binding(engine)
+    _add_collaborator(engine, binding_id, "user_other")
+    resp = client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_outsider"},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["other"]),
+    )
+    assert resp.status_code == 403
+
+
+def test_non_collaborator_forbidden() -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    binding_id = _seed_binding(engine)
+    resp = client.put(
+        f"/api/enterprise/channels/{binding_id}",
+        json={"auto_route": False},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["outsider"]),
+    )
+    assert resp.status_code == 403
+
+
+def test_list_visible_to_collaborator_and_my_role() -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    binding_id = _seed_binding(engine)
+    _add_collaborator(engine, binding_id, "user_other")
+    other_items = client.get(
+        "/api/enterprise/channels",
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["other"]),
+    ).json()
+    assert any(b["id"] == binding_id for b in other_items)
+    mine = next(b for b in other_items if b["id"] == binding_id)
+    assert mine["my_role"] == "collaborator"
+    owner_items = client.get(
+        "/api/enterprise/channels",
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["owner"]),
+    ).json()
+    own = next(b for b in owner_items if b["id"] == binding_id)
+    assert own["my_role"] == "owner"
+    admin_items = client.get(
+        "/api/enterprise/channels",
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["admin"]),
+    ).json()
+    adm = next(b for b in admin_items if b["id"] == binding_id)
+    assert adm["my_role"] == "admin"
+    # 未被授权的用户看不到该绑定
+    outsider_items = client.get(
+        "/api/enterprise/channels",
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["outsider"]),
+    ).json()
+    assert not any(b["id"] == binding_id for b in outsider_items)
+
+
+def test_add_remove_collaborator_revokes_access() -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    binding_id = _seed_binding(engine)
+    add = client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_other"},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["owner"]),
+    )
+    assert add.status_code == 201
+    assert client.put(
+        f"/api/enterprise/channels/{binding_id}",
+        json={"auto_route": False},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["other"]),
+    ).status_code == 200
+    dele = client.delete(
+        f"/api/enterprise/channels/{binding_id}/managers/user_other",
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["owner"]),
+    )
+    assert dele.status_code == 204
+    assert client.put(
+        f"/api/enterprise/channels/{binding_id}",
+        json={"auto_route": True},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["other"]),
+    ).status_code == 403
+    # 重新添加恢复权限(复活已撤销行)
+    client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_other"},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["owner"]),
+    )
+    assert client.put(
+        f"/api/enterprise/channels/{binding_id}",
+        json={"auto_route": True},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["other"]),
+    ).status_code == 200
+
+
+def test_add_collaborator_validations() -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    binding_id = _seed_binding(engine)
+    headers = _auth(users["owner"])
+    params = {"tenant_id": "tenant_demo"}
+    # 创建者无需添加
+    assert client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_owner"},
+        params=params,
+        headers=headers,
+    ).status_code == 400
+    # 管理员无需添加
+    assert client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_admin"},
+        params=params,
+        headers=headers,
+    ).status_code == 400
+    # 不存在用户
+    assert client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_nope"},
+        params=params,
+        headers=headers,
+    ).status_code == 400
+    # 正常添加
+    assert client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_other"},
+        params=params,
+        headers=headers,
+    ).status_code == 201
+    # 重复添加
+    assert client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_other"},
+        params=params,
+        headers=headers,
+    ).status_code == 409
+
+
+def test_admin_can_manage_managers() -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    binding_id = _seed_binding(engine)
+    resp = client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_other"},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["admin"]),
+    )
+    assert resp.status_code == 201
+
+
+def test_list_managers() -> None:
+    engine = _engine()
+    users = _seed(engine)
+    client = _client(engine)
+    binding_id = _seed_binding(engine)
+    client.post(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        json={"user_id": "user_other"},
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["owner"]),
+    )
+    resp = client.get(
+        f"/api/enterprise/channels/{binding_id}/managers",
+        params={"tenant_id": "tenant_demo"},
+        headers=_auth(users["owner"]),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["user_id"] == "user_other"
+    assert data[0]["name"] == "other"
+    assert data[0]["granted_by_user_id"] == "user_owner"

--- a/frontend-enterprise/src/pages/ChannelsPage.tsx
+++ b/frontend-enterprise/src/pages/ChannelsPage.tsx
@@ -272,7 +272,12 @@ export default function ChannelsPage({
 
   const binding = bindings.find((item) => item.id === selectedId) || null;
   const navigate = useNavigate();
-  const channelIdentities = identityBindings.filter((item) => item.channel === binding?.channel);
+  // 身份绑定属于具体渠道账号 scope；同一用户可以分别绑定多个飞书应用。
+  const channelIdentities = identityBindings.filter(
+    (item) =>
+      item.channel === binding?.channel &&
+      (item.external_account_scope || '') === (binding?.identity_scope_key || ''),
+  );
   const bindCodeChannelName = binding
     ? channelName(binding.channel)
     : getChannelPresentation(createChannel).name;
@@ -984,6 +989,7 @@ export default function ChannelsPage({
                   const matchingIdentity = user.channel_identities?.find(
                     (ci) => ci.channel === binding.channel && (ci.external_account_scope || '') === scope,
                   );
+                  if (binding.channel === 'feishu' && !matchingIdentity) return null;
                   const channelLabel = matchingIdentity
                     ? ` (${_CHANNEL_LABELS[matchingIdentity.channel] || matchingIdentity.channel} 可达)`
                     : user.channel_identities?.[0]

--- a/frontend-enterprise/src/pages/ChannelsPage.tsx
+++ b/frontend-enterprise/src/pages/ChannelsPage.tsx
@@ -265,6 +265,9 @@ export default function ChannelsPage({
   const [bindCodeOpen, setBindCodeOpen] = useState(false);
   const [bindCodeLoading, setBindCodeLoading] = useState(false);
   const [bindCodeRemain, setBindCodeRemain] = useState(0);
+  const [bindCodeTargetName, setBindCodeTargetName] = useState('');
+  const [bindCodeTargetUserId, setBindCodeTargetUserId] = useState<string | undefined>();
+  const [identityInviteUserId, setIdentityInviteUserId] = useState('');
   const [identityBindings, setIdentityBindings] = useState<ChannelIdentityBindingRead[]>([]);
   const [unbindIdentityTarget, setUnbindIdentityTarget] =
     useState<ChannelIdentityBindingRead | null>(null);
@@ -277,6 +280,19 @@ export default function ChannelsPage({
     (item) =>
       item.channel === binding?.channel &&
       (item.external_account_scope || '') === (binding?.identity_scope_key || ''),
+  );
+  const bindingScope = binding?.identity_scope_key || '';
+  const identityBoundUsers = tenantUsers.filter((user) =>
+    user.channel_identities?.some(
+      (identity) =>
+        identity.channel === binding?.channel &&
+        (identity.external_account_scope || '') === bindingScope,
+    ),
+  );
+  const identityUnboundUsers = tenantUsers.filter(
+    (user) =>
+      (!user.source || user.source === 'web') &&
+      !identityBoundUsers.some((bound) => bound.id === user.id),
   );
   const bindCodeChannelName = binding
     ? channelName(binding.channel)
@@ -542,14 +558,24 @@ export default function ChannelsPage({
     }
   }
 
-  async function openBindCode() {
+  async function openBindCode(targetUserId?: string) {
     if (bindCodeLoading) return;
     setBindCodeLoading(true);
     try {
-      const result = await api.post<ChannelBindCodeRead>(
-        `/api/enterprise/channels/bind-code?tenant_id=${TENANT_ID}`,
-      );
+      const target = targetUserId
+        ? tenantUsers.find((user) => user.id === targetUserId)
+        : currentUser;
+      const result = targetUserId && binding
+        ? await api.post<ChannelBindCodeRead>(
+            `/api/enterprise/channels/${binding.id}/identity-bind-code?tenant_id=${TENANT_ID}`,
+            { user_id: targetUserId },
+          )
+        : await api.post<ChannelBindCodeRead>(
+            `/api/enterprise/channels/bind-code?tenant_id=${TENANT_ID}`,
+          );
       setBindCode(result);
+      setBindCodeTargetName(target?.display_name || target?.username || '当前用户');
+      setBindCodeTargetUserId(targetUserId);
       setBindCodeOpen(true);
     } catch (error) {
       notify.error(error instanceof Error ? error.message : '生成绑定码失败');
@@ -1054,6 +1080,52 @@ export default function ChannelsPage({
               >
                 {`绑定我的${channelName(binding.channel)}`}
               </UIButton>
+            </div>
+          )}
+          {canManageBinding(binding) && binding.channel === 'feishu' && (
+            <div className="mt-[4px] flex flex-col gap-[10px] border-t border-[#eef0f4] pt-[12px]">
+              <div className="flex flex-col gap-[3px]">
+                <span className="text-[12px] font-medium text-[#18181a]">邀请成员绑定飞书身份</span>
+                <span className="text-[11px] leading-[1.6] text-[#858b9c]">
+                  每位成员需用自己的飞书账号向当前机器人发送一次性绑定指令。
+                </span>
+              </div>
+              {identityBoundUsers.length > 0 && (
+                <div className="flex flex-wrap gap-[6px]">
+                  {identityBoundUsers.map((user) => (
+                    <StatusBadge key={user.id} tone="green">
+                      {`${user.display_name || user.username} 已绑定`}
+                    </StatusBadge>
+                  ))}
+                </div>
+              )}
+              {identityUnboundUsers.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-[8px]">
+                  <Select value={identityInviteUserId || '__none__'} onValueChange={(value) => setIdentityInviteUserId(value === '__none__' ? '' : value)}>
+                    <SelectTrigger className="h-[32px] w-[180px] text-[12px]">
+                      <SelectValue placeholder="选择内部成员" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__none__">选择内部成员</SelectItem>
+                      {identityUnboundUsers.map((user) => (
+                        <SelectItem key={user.id} value={user.id}>
+                          {user.display_name || user.username || user.id}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <UIButton
+                    variant="outline"
+                    disabled={!identityInviteUserId || bindCodeLoading}
+                    onClick={() => void openBindCode(identityInviteUserId)}
+                    className={OUTLINE_BUTTON_CLASS}
+                  >
+                    生成绑定指令
+                  </UIButton>
+                </div>
+              ) : (
+                <span className="text-[11px] text-[#858b9c]">所有内部成员均已绑定当前飞书应用</span>
+              )}
             </div>
           )}
         </div>
@@ -1561,7 +1633,7 @@ export default function ChannelsPage({
           className="flex w-[calc(100%-2rem)] flex-col gap-[16px] overflow-hidden rounded-[14px] px-[20px] py-[16px] sm:max-w-[420px]"
         >
           <DialogTitle className="text-[14px] font-normal leading-none text-[#757f9c]">
-            {`绑定我的${bindCodeChannelName}`}
+            {`绑定${bindCodeTargetName ? ` ${bindCodeTargetName} 的` : ''}${bindCodeChannelName}身份`}
           </DialogTitle>
           {bindCode && (
             <div className="flex flex-col items-center gap-[12px]">
@@ -1584,11 +1656,11 @@ export default function ChannelsPage({
                 </UIButton>
               </div>
               <span className="text-center text-[12px] leading-[1.6] text-[#858b9c]">
-                {`请在${bindCodeChannelName}中向你的数字员工发送以上指令，完成身份绑定。`}
+                {`请让${bindCodeTargetName || '该成员'}使用自己的${bindCodeChannelName}账号向当前机器人发送以上指令。`}
               </span>
               {bindCodeRemain === 0 && (
                 <UIButton
-                  onClick={() => void openBindCode()}
+                  onClick={() => void openBindCode(bindCodeTargetUserId)}
                   disabled={bindCodeLoading}
                   className={PRIMARY_BUTTON_CLASS}
                 >

--- a/frontend-enterprise/src/pages/ChannelsPage.tsx
+++ b/frontend-enterprise/src/pages/ChannelsPage.tsx
@@ -55,7 +55,13 @@ import WechatSetup from './channels/WechatSetup';
 import WecomSetup from './channels/WecomSetup';
 import FeishuSetup from './channels/FeishuSetup';
 import DingTalkSetup from './channels/DingTalkSetup';
-import { getChannelPresentation } from './channelPresentation';
+import BindingManagers from './channels/BindingManagers';
+import {
+  canDeleteBinding,
+  canManageBinding,
+  getChannelPresentation,
+  ROLE_LABEL,
+} from './channelPresentation';
 import { StatusBadge } from './scheduled-tasks/StatusBadge';
 import { formatTime, type BadgeTone } from './scheduled-tasks/shared';
 
@@ -245,6 +251,7 @@ export default function ChannelsPage({
   const [creating, setCreating] = useState(false);
   const [unbindOpen, setUnbindOpen] = useState(false);
   const [unbinding, setUnbinding] = useState(false);
+  const [togglingStatus, setTogglingStatus] = useState(false);
   const [agentEditing, setAgentEditing] = useState(false);
   const [agentCandidates, setAgentCandidates] = useState<AgentProfileRead[]>([]);
   const [candidatesLoading, setCandidatesLoading] = useState(false);
@@ -573,6 +580,22 @@ export default function ChannelsPage({
     }
   }
 
+  async function toggleStatus() {
+    if (!binding) return;
+    setTogglingStatus(true);
+    try {
+      const updated = await api.post<ChannelBindingRead>(
+        `/api/enterprise/channels/${binding.id}/toggle-status?tenant_id=${TENANT_ID}`,
+      );
+      setBindings((current) => current.map((item) => (item.id === updated.id ? updated : item)));
+      notify.success(updated.status === 'active' ? '已启用渠道' : '已停用渠道');
+    } catch (error) {
+      notify.error(error instanceof Error ? error.message : '切换状态失败');
+    } finally {
+      setTogglingStatus(false);
+    }
+  }
+
   function openAgentEdit() {
     const mounted = binding?.agents || [];
     setSelectedAgentIds(new Set(mounted.map((item) => item.agent_id)));
@@ -857,15 +880,32 @@ export default function ChannelsPage({
             <span className="truncate text-[12px] text-[#858b9c]">
               创建者：{binding.created_by_name || '-'}
             </span>
+            {binding.my_role && (
+              <span className="rounded-[6px] bg-[#f0f1f5] px-[6px] py-[2px] text-[11px] text-[#858b9c]">
+                {ROLE_LABEL[binding.my_role] || binding.my_role}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-[8px]">
-            <UIButton
-              variant="outline"
-              onClick={() => setUnbindOpen(true)}
-              className={OUTLINE_BUTTON_CLASS}
-            >
-              断开接入
-            </UIButton>
+            {canManageBinding(binding) && (
+              <UIButton
+                variant="outline"
+                onClick={() => void toggleStatus()}
+                disabled={togglingStatus}
+                className={OUTLINE_BUTTON_CLASS}
+              >
+                {binding.status === 'active' ? '停用' : '启用'}
+              </UIButton>
+            )}
+            {canDeleteBinding(binding) && (
+              <UIButton
+                variant="outline"
+                onClick={() => setUnbindOpen(true)}
+                className={OUTLINE_BUTTON_CLASS}
+              >
+                断开接入
+              </UIButton>
+            )}
           </div>
         </div>
         {binding.status === 'expired' && setupKindFor(binding.channel) !== 'qrcode' && (
@@ -960,6 +1000,13 @@ export default function ChannelsPage({
             </Select>
           </div>
         </div>
+        {canDeleteBinding(binding) && (
+          <BindingManagers
+            bindingId={binding.id}
+            users={tenantUsers}
+            creatorUserId={binding.created_by_user_id}
+          />
+        )}
       </div>
 
       <section aria-label={activeChannel ? `${activeChannel.name}身份绑定` : '身份绑定'}>

--- a/frontend-enterprise/src/pages/channelPresentation.test.ts
+++ b/frontend-enterprise/src/pages/channelPresentation.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { getChannelPresentation } from './channelPresentation';
+import {
+  canDeleteBinding,
+  canManageBinding,
+  getChannelPresentation,
+  ROLE_LABEL,
+} from './channelPresentation';
 
 describe('channel presentation', () => {
   it.each([
@@ -20,5 +25,33 @@ describe('channel presentation', () => {
     expect(presentation.name).toBe('内部协作');
     expect(presentation.userLabel).toBe('内部协作用户');
     expect(presentation.blurb).toBe('通过内部协作与数字员工对话。');
+  });
+});
+
+describe('channel binding manager roles', () => {
+  it.each([
+    ['admin', true],
+    ['owner', true],
+    ['collaborator', false],
+    [null, false],
+    [undefined, false],
+  ])('my_role=%s can delete binding? %s', (role, expected) => {
+    expect(canDeleteBinding({ my_role: (role as string | null | undefined) ?? null })).toBe(expected);
+  });
+
+  it.each([
+    ['admin', true],
+    ['owner', true],
+    ['collaborator', true],
+    [null, false],
+    [undefined, false],
+  ])('my_role=%s can manage binding? %s', (role, expected) => {
+    expect(canManageBinding({ my_role: (role as string | null | undefined) ?? null })).toBe(expected);
+  });
+
+  it('exposes role labels for known roles', () => {
+    expect(ROLE_LABEL.admin).toBe('管理员');
+    expect(ROLE_LABEL.owner).toBe('拥有者');
+    expect(ROLE_LABEL.collaborator).toBe('协作者');
   });
 });

--- a/frontend-enterprise/src/pages/channelPresentation.ts
+++ b/frontend-enterprise/src/pages/channelPresentation.ts
@@ -1,3 +1,5 @@
+import type { ChannelBindingRead } from '../types';
+
 export type ChannelPresentation = {
   name: string;
   identifierLabel: string;
@@ -50,4 +52,24 @@ export function getChannelPresentation(channel: string, configuredName?: string)
       preset?.disconnectDescription ||
       `断开后${name}接入将停止服务，需要重新配置该渠道才能恢复；对话记录保留。确定断开接入吗？`,
   };
+}
+
+export const ROLE_LABEL: Record<string, string> = {
+  admin: '管理员',
+  owner: '拥有者',
+  collaborator: '协作者',
+};
+
+/** 仅创建者与管理员可删除渠道绑定/管理协作者名单 */
+export function canDeleteBinding(binding: Pick<ChannelBindingRead, 'my_role'>): boolean {
+  return binding.my_role === 'owner' || binding.my_role === 'admin';
+}
+
+/** 创建者/管理员/协作者可配置凭证、管理挂载员工、启停渠道 */
+export function canManageBinding(binding: Pick<ChannelBindingRead, 'my_role'>): boolean {
+  return (
+    binding.my_role === 'owner' ||
+    binding.my_role === 'admin' ||
+    binding.my_role === 'collaborator'
+  );
 }

--- a/frontend-enterprise/src/pages/channels/BindingManagers.tsx
+++ b/frontend-enterprise/src/pages/channels/BindingManagers.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react';
+
+import { notify } from '@/components/ui/app-toast';
+import { Button as UIButton } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui';
+
+import { api, TENANT_ID } from '../../api/client';
+import type { ChannelBindingManagerRead } from '../../types';
+
+type TenantUser = {
+  id: string;
+  username: string;
+  display_name?: string;
+  source?: string;
+};
+
+type Props = {
+  bindingId: string;
+  users: TenantUser[];
+  creatorUserId?: string | null;
+};
+
+export default function BindingManagers({ bindingId, users, creatorUserId }: Props) {
+  const [managers, setManagers] = useState<ChannelBindingManagerRead[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [candidate, setCandidate] = useState('');
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bindingId]);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const data = await api.get<ChannelBindingManagerRead[]>(
+        `/api/enterprise/channels/${bindingId}/managers?tenant_id=${TENANT_ID}`,
+      );
+      setManagers(data);
+    } catch (error) {
+      notify.error(error instanceof Error ? error.message : '加载协作者失败');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const existingIds = new Set(managers.map((m) => m.user_id));
+  const candidates = users.filter(
+    (u) => (!u.source || u.source === 'web') && u.id !== creatorUserId && !existingIds.has(u.id),
+  );
+
+  async function add() {
+    if (!candidate) return;
+    setAdding(true);
+    try {
+      await api.post(`/api/enterprise/channels/${bindingId}/managers?tenant_id=${TENANT_ID}`, {
+        user_id: candidate,
+      });
+      setCandidate('');
+      await load();
+      notify.success('已添加协作者');
+    } catch (error) {
+      notify.error(error instanceof Error ? error.message : '添加协作者失败');
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function remove(userId: string) {
+    try {
+      await api.delete(
+        `/api/enterprise/channels/${bindingId}/managers/${userId}?tenant_id=${TENANT_ID}`,
+      );
+      await load();
+      notify.success('已移除协作者');
+    } catch (error) {
+      notify.error(error instanceof Error ? error.message : '移除协作者失败');
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-[12px] border-t border-[#eef0f4] pt-[16px]">
+      <div className="flex min-w-0 flex-col gap-[4px]">
+        <span className="text-[13px] font-semibold text-[#18181a]">协作者管理</span>
+        <span className="text-[12px] leading-[1.6] text-[#858b9c]">
+          协作者可配置/轮换凭证、管理挂载员工、启停渠道，但不能删除渠道或管理其他协作者。
+        </span>
+      </div>
+      {loading ? (
+        <span className="text-[12px] text-[#858b9c]">加载中…</span>
+      ) : managers.length === 0 ? (
+        <span className="text-[12px] text-[#858b9c]">暂无协作者</span>
+      ) : (
+        <ul className="flex flex-col gap-[8px]">
+          {managers.map((m) => (
+            <li key={m.user_id} className="flex items-center justify-between gap-[12px]">
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate text-[12px] text-[#18181a]">{m.name || m.user_id}</span>
+                <span className="text-[11px] text-[#858b9c]">
+                  授权人：{m.granted_by_name || m.granted_by_user_id || '-'}
+                </span>
+              </div>
+              <UIButton
+                variant="outline"
+                className="h-7 rounded-[8px] border-[#e3e7f1] px-3 text-[11px] text-[#464c5e] hover:bg-[#f6f6f6]"
+                onClick={() => void remove(m.user_id)}
+              >
+                移除
+              </UIButton>
+            </li>
+          ))}
+        </ul>
+      )}
+      {candidates.length > 0 ? (
+        <div className="flex items-center gap-[8px]">
+          <Select value={candidate || '__none__'} onValueChange={(v) => setCandidate(v === '__none__' ? '' : v)}>
+            <SelectTrigger className="h-[32px] w-[180px] text-[12px]">
+              <SelectValue placeholder="选择成员" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__none__">未选择</SelectItem>
+              {candidates.map((u) => (
+                <SelectItem key={u.id} value={u.id}>
+                  {u.display_name || u.username || u.id}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <UIButton
+            variant="outline"
+            className="h-8 rounded-[8px] border-[#e3e7f1] px-4 text-[12px] text-[#464c5e] hover:bg-[#f6f6f6]"
+            disabled={adding || !candidate}
+            onClick={() => void add()}
+          >
+            添加
+          </UIButton>
+        </div>
+      ) : (
+        <span className="text-[11px] text-[#858b9c]">无可添加的成员（协作者须为当前租户内部成员，且排除创建者与管理员）</span>
+      )}
+    </div>
+  );
+}

--- a/frontend-enterprise/src/types/index.ts
+++ b/frontend-enterprise/src/types/index.ts
@@ -893,8 +893,18 @@ export type ChannelBindingRead = {
   default_handoff_assignee_user_id?: string | null;
   default_handoff_assignee_name?: string | null;
   identity_scope_key?: string | null;
+  /** 当前请求者对该绑定的管理角色:admin/owner/collaborator;无关系时为 null */
+  my_role?: string | null;
   created_at: string;
   updated_at: string;
+};
+
+export type ChannelBindingManagerRead = {
+  user_id: string;
+  name?: string | null;
+  granted_at: string;
+  granted_by_user_id?: string | null;
+  granted_by_name?: string | null;
 };
 
 export type ChannelDeliveryRead = {


### PR DESCRIPTION
## 意图

解决飞书渠道绑定「仅创建者一人能管理」的限制：允许创建者显式添加协作者，协作者可配置/轮换凭证、管理挂载员工、启停渠道，但不能删除渠道或管理其他协作者。

## 改动

**后端**
- 新增 `ChannelBindingManager` 表（软撤销 `revoked_at` + 审计字段；`create_all` 自动建表，无需迁移）
- `_ensure_binding_manager` 改为按 `action` 粒度校验（`manage_credentials` / `manage_agents` / `toggle_status` 放行协作者）
- `list_channel_bindings` 放开协作者可见性，并在 `ChannelBindingRead` 上返回 `my_role`（admin/owner/collaborator）
- 新增 `GET/POST/DELETE /{binding_id}/managers` 协作者管理端点（加/移/列；移除走软撤销，重新添加复活该行）
- 新增 `POST /{binding_id}/toggle-status` 启停渠道端点（停用 quiesce 长连接，启用按需 resume，复用凭证保存/删除同款生命周期管理）

**前端**
- 渠道详情新增角色徽标、启停按钮、协作者管理面板
- 断开接入按钮按 `my_role` 显隐（仅 owner/admin）
- 新增 `BindingManagers.tsx` 组件（复用 `tenantUsers` 做成员选择，排除创建者/管理员/已有协作者）
- 权限纯函数提取到 `channelPresentation.ts`（`canDeleteBinding` / `canManageBinding` / `ROLE_LABEL`）

## 权限边界

| 操作 | admin | 创建者 | 协作者 | 其他成员 |
|---|:---:|:---:|:---:|:---:|
| 配置/轮换凭证 | ✅ | ✅ | ✅ | ❌ |
| 管理挂载员工 | ✅ | ✅ | ✅ | ❌ |
| 启停渠道 | ✅ | ✅ | ✅ | ❌ |
| 删除渠道 | ✅ | ✅ | ❌ | ❌ |
| 管理协作者名单 | ✅ | ✅ | ❌ | ❌ |
| 查看投递/会话记录 | ✅ | ✅ | ❌ | ❌ |

## 风险

- **启停渠道**为补齐的缺失功能（之前无独立端点，状态切换仅发生在凭证保存路径）；停用走 quiesce 断长连接 + `status=disabled`，启用 `status=active` + 有凭证时 resume，与既有删除/凭证保存同款 quiesce/resume 范式。
- **凭证安全**：`ChannelBindingRead` 注释明确「绝不回传凭证明文」，`app_secret` 不在读取视图；协作者只能重填/轮换，无法查看明文。
- **协作者变更**走软撤销（`revoked_at`）保留 who/when 审计；同一 (binding, user) 仅一行，重新添加复活而非新增。
- 投递日志/会话记录等只读查看端点维持原行为（仅创建者+admin），协作者暂不可见，如需放开可后续加 `view` action。

## 测试

- **后端**：新增 `test_channel_managers.py`（11 个用例：协作者能配凭证/管挂载/启停、不能删除/不能管协作者、非协作者 403、列表可见性与 my_role、软撤销后失去权限再添加恢复、添加校验 400/409、admin 可管协作者）；既有 channel 套件 455 passed，零破坏。
- **前端**：`tsc` + `vite build` 通过；vitest 186 passed（新增 11 个 `channelPresentation` 权限函数用例）。
- `config:check` 通过；`i18n:check` exit 1 为既有状态（改动前即失败），跟随既有中文硬编码风格。

## UI 验证

- 路由：`/enterprise/channels` → 飞书渠道详情
- 角色：创建者、协作者、管理员分别验证「断开接入 / 启停 / 协作者管理面板」的显隐与可用性
