### PR TITLE
fix(dashboard): prevent stale evolution proposals after employee switch

### DIFF
--- a/frontend-enterprise/src/pages/dashboard/DashboardPage.test.tsx
+++ b/frontend-enterprise/src/pages/dashboard/DashboardPage.test.tsx
@@ -63,6 +63,7 @@ describe('DashboardPage team scope compatibility', () => {
       if (url.includes('/work-record')) {
         return jsonResponse({ reply_stats: { total: 0, today: 0, by_day: {} }, events: [] });
       }
+      if (url.includes('/evolution/proposals')) return jsonResponse([]);
       if (url.includes('/api/enterprise/agents')) return jsonResponse([agent]);
       if (url.includes('/api/enterprise/feedback/summary')) {
         return jsonResponse({ total_feedback: 0, up_count: 0, down_count: 0, bucket_counts: [] });

--- a/frontend-enterprise/src/pages/dashboard/EvolutionPanel.test.tsx
+++ b/frontend-enterprise/src/pages/dashboard/EvolutionPanel.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { I18nProvider } from '@/i18n';
+
+import EvolutionPanel from './EvolutionPanel';
+
+type DeferredResponse = {
+  promise: Promise<Response>;
+  resolve: (body: unknown) => void;
+};
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+function deferredResponse(): DeferredResponse {
+  let resolvePromise: (response: Response) => void = () => {};
+  const promise = new Promise<Response>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: (body) => resolvePromise(jsonResponse(body)),
+  };
+}
+
+function proposal(id: string, resourceName: string) {
+  return {
+    id,
+    resource_type: 'sop',
+    resource_name: resourceName,
+    resource_key: `sop:${id}`,
+    status: 'ready_for_review',
+    risk_level: 'low',
+    hypothesis: `${resourceName} 的改进假设`,
+    rationale: '来自真实反馈',
+    expected_outcome: '提升执行质量',
+    source_feedback_ids: ['feedback-1'],
+    evidence: [],
+    diff: [],
+    evaluation: {},
+    created_at: '2026-08-20T00:00:00Z',
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('EvolutionPanel employee switching', () => {
+  it('hides the previous employee proposals while the next employee is loading', async () => {
+    const agentBResponse = deferredResponse();
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/agents/agent-a/')) {
+        return Promise.resolve(jsonResponse([proposal('proposal-a', '员工 A 的候选')]));
+      }
+      if (url.includes('/agents/agent-b/')) return agentBResponse.promise;
+      return Promise.resolve(jsonResponse([]));
+    }));
+
+    const { rerender } = render(
+      <I18nProvider>
+        <EvolutionPanel agentId="agent-a" />
+      </I18nProvider>,
+    );
+    expect(await screen.findByText('员工 A 的候选')).toBeTruthy();
+
+    rerender(
+      <I18nProvider>
+        <EvolutionPanel agentId="agent-b" />
+      </I18nProvider>,
+    );
+
+    expect(screen.queryByText('员工 A 的候选')).toBeNull();
+  });
+
+  it('ignores a previous employee response that arrives after the current employee response', async () => {
+    const agentAResponse = deferredResponse();
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/agents/agent-a/')) return agentAResponse.promise;
+      if (url.includes('/agents/agent-b/')) {
+        return Promise.resolve(jsonResponse([proposal('proposal-b', '员工 B 的候选')]));
+      }
+      return Promise.resolve(jsonResponse([]));
+    }));
+
+    const { rerender } = render(
+      <I18nProvider>
+        <EvolutionPanel agentId="agent-a" />
+      </I18nProvider>,
+    );
+    rerender(
+      <I18nProvider>
+        <EvolutionPanel agentId="agent-b" />
+      </I18nProvider>,
+    );
+    expect(await screen.findByText('员工 B 的候选')).toBeTruthy();
+
+    // 模拟较早发出的员工 A 请求在员工 B 已展示后才返回。
+    await act(async () => {
+      agentAResponse.resolve([proposal('proposal-a', '员工 A 的候选')]);
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('员工 A 的候选')).toBeNull();
+    expect(screen.getByText('员工 B 的候选')).toBeTruthy();
+  });
+});

--- a/frontend-enterprise/src/pages/dashboard/EvolutionPanel.tsx
+++ b/frontend-enterprise/src/pages/dashboard/EvolutionPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, notify } from '@/components/ui';
 import StaffdeckIcon from '@/components/StaffdeckIcon';
 import { api, ApiError, TENANT_ID } from '@/api/client';
@@ -63,27 +63,47 @@ const LEGACY_EVOLUTION_ERRORS: Record<string, string> = {
 
 export default function EvolutionPanel({ agentId }: { agentId: string }) {
   const { t } = useI18n();
-  const [rows, setRows] = useState<EvolutionProposal[]>([]);
+  const [proposalState, setProposalState] = useState<{ agentId: string; rows: EvolutionProposal[] }>({
+    agentId,
+    rows: [],
+  });
   const [instruction, setInstruction] = useState('');
   const [loading, setLoading] = useState(true);
   const [busyAction, setBusyAction] = useState('');
+  const currentAgentIdRef = useRef(agentId);
+  const loadSequenceRef = useRef(0);
+  currentAgentIdRef.current = agentId;
+
+  // 数据归属与当前员工不一致时不参与渲染，避免 effect 执行前出现上一位员工的候选。
+  const rows = proposalState.agentId === agentId ? proposalState.rows : [];
 
   const load = useCallback(async () => {
+    const requestedAgentId = agentId;
+    if (currentAgentIdRef.current !== requestedAgentId) return;
+    const loadSequence = ++loadSequenceRef.current;
     setLoading(true);
     try {
       const result = await api.get<EvolutionProposal[]>(
-        `/api/enterprise/agents/${encodeURIComponent(agentId)}/evolution/proposals?tenant_id=${encodeURIComponent(TENANT_ID)}`,
+        `/api/enterprise/agents/${encodeURIComponent(requestedAgentId)}/evolution/proposals?tenant_id=${encodeURIComponent(TENANT_ID)}`,
       );
-      setRows(result);
+      if (loadSequence !== loadSequenceRef.current || currentAgentIdRef.current !== requestedAgentId) return;
+      setProposalState({ agentId: requestedAgentId, rows: result });
     } catch (error) {
+      if (loadSequence !== loadSequenceRef.current || currentAgentIdRef.current !== requestedAgentId) return;
       notify.error(localizeEvolutionError(error, '加载自进化候选失败', t));
     } finally {
-      setLoading(false);
+      if (loadSequence === loadSequenceRef.current && currentAgentIdRef.current === requestedAgentId) {
+        setLoading(false);
+      }
     }
   }, [agentId, t]);
 
   useEffect(() => {
     void load();
+    return () => {
+      // 组件卸载或员工变化时，使所有尚未完成的旧请求失效。
+      loadSequenceRef.current += 1;
+    };
   }, [load]);
 
   const activeCount = useMemo(


### PR DESCRIPTION
## Summary

- keep evolution proposals scoped to the currently selected employee before rendering
- invalidate superseded loads so an older employee response cannot overwrite the current employee data
- add regression coverage for both the loading-window leak and out-of-order response race
- fix the dashboard test mock so the evolution endpoint returns the correct response shape

## Reproduction

1. Open employee A and wait for its evolution proposals to load.
2. Switch to employee B while B's proposal request is still pending.
3. Employee A's proposals remain visible and actionable during the load.
4. With overlapping requests, a late response for employee A can overwrite employee B's already loaded proposals.

Because proposal actions are issued by proposal ID, stale rows could lead an administrator to act on the previous employee's proposal from the current employee view.

## Validation

- `npm test` — 46 test files, 202 tests passed
- `npm run build`
- `npm run i18n:check`
- `npm run config:check`