### PR TITLE
fix(lint): move module-level statements out of import blocks

### DIFF
--- a/backend/app/api/skills.py
+++ b/backend/app/api/skills.py
@@ -55,9 +55,6 @@ from app.security.permissions import (
 )
 from app.security.tenant import ensure_tenant
 from app.skills import SkillDistiller, SkillEditor
-
-_CHANNEL_LABELS = {"wechat": "微信", "wecom": "企业微信", "feishu": "飞书", "dingtalk": "钉钉"}
-
 from app.skills.skill_schema import (
     SkillCard,
     SkillCreateRequest,
@@ -80,6 +77,8 @@ from app.skills.nesting import (
     sop_capability_scope,
     validate_sop_nesting,
 )
+
+_CHANNEL_LABELS = {"wechat": "微信", "wecom": "企业微信", "feishu": "飞书", "dingtalk": "钉钉"}
 
 router = APIRouter(
     prefix="/api/enterprise/skills",

--- a/backend/app/core/agent_loop.py
+++ b/backend/app/core/agent_loop.py
@@ -58,8 +58,6 @@ from app.llm.model_config_resolver import (
     resolve_model_config_for_runtime,
 )
 from app.llm.stage_protocol import stage_payload, unified_system_prompt
-
-logger = logging.getLogger(__name__)
 from app.memory.jobs import enqueue_memory_capture
 from app.memory.service import MemoryService
 from app.observability import EventLog
@@ -74,6 +72,8 @@ from app.session.session_schema import (
     StepAgentResult,
 )
 from app.tools.tool_schema import ToolResult
+
+logger = logging.getLogger(__name__)
 
 STREAM_CHUNK_INTERVAL_SECONDS = 0.045
 MAX_TOOL_ACTIONS_PER_TURN = 32

--- a/backend/tests/test_channel_routing.py
+++ b/backend/tests/test_channel_routing.py
@@ -622,7 +622,7 @@ def test_delete_agent_cleans_channel_mounts_and_repoints_default() -> None:
 
     client = _make_agents_client(engine)
     deleted = client.delete(
-        f"/api/enterprise/agents/agent_cw?tenant_id=tenant_demo",
+        "/api/enterprise/agents/agent_cw?tenant_id=tenant_demo",
         headers=_auth(users["owner"]),
     )
     assert deleted.status_code == 200
@@ -671,7 +671,7 @@ def test_delete_agent_last_mount_keeps_binding_agent() -> None:
 
     client = _make_agents_client(engine)
     deleted = client.delete(
-        f"/api/enterprise/agents/agent_cw?tenant_id=tenant_demo",
+        "/api/enterprise/agents/agent_cw?tenant_id=tenant_demo",
         headers=_auth(users["owner"]),
     )
     assert deleted.status_code == 200


### PR DESCRIPTION
## Problem                                                                          
Two module-level statements sit inside import blocks, which makes every import that follows them a module-level import after code (E402):

- `backend/app/core/agent_loop.py:62` — `logger = logging.getLogger(__name__)` is placed mid-block, so the 9 imports after it are flagged.
- `backend/app/api/skills.py:59` — `_CHANNEL_LABELS = {...}` does the same for the 4 imports after it.
`backend/tests/test_channel_routing.py` also has two f-strings with no placeholders (F541).

```
$ ruff check backend --select E4,E7,E9,F,W
Found 15 errors.
```

All 15 were introduced in 008fff3.

## Change

Move both statements below their import blocks and drop the `f` prefix from the two constant URLs. No behaviour changes. 

## Why this is safe

- Neither value is read at import time: `logger` is only used in `agent_loop.py:837`, `_CHANNEL_LABELS` only in `skills.py:256` and `:296`.
- Nothing imports these symbols, so there is no circular-import path that could depend on their position — other modules only import `AgentLoop`, `create_skill` and `router`.                                                      
- `agent_cw` is a hard-coded id throughout `test_channel_routing.py` (see line 48), so the two f-strings were leftovers rather than a missing interpolation.

`logger` is moved rather than removed, since it has a real call site.

## Note on visibility

These findings do not all show up in a default `ruff check backend` run. `[tool.ruff]` currently sets only `line-length` and `target-version`, so the active rule set is whatever the installed ruff defaults to; on ruff 0.16.4 that is 413 rules and 1983 findings, and E402 is **not** among the enabled rules. The 13 E402 findings above are therefore invisible under the current configuration and only surface when the rule set is stated explicitly.

Pinning that rule set is a separate concern and I am happy to open a follow-up for it; this PR only fixes the code. configuration and only surface when the rule set is stated explicitly.

Pinning that rule set is a separate concern and I am happy to open a follow-up for it; this PR only fixes the code.

## Tests

Run on this branch:

- `ruff check backend --select E4,E7,E9,F,W` — passes (was 15 errors)
- `pytest backend/tests` — 1997 passed
- `python -c "import app.core.agent_loop, app.api.skills"` — both import cleanly

## UI validation

Not applicable: no route, template or rendered output is affected.

