### PR TITLE
fix(llm): send an honest outbound User-Agent to avoid WAF false positives

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -88,7 +88,7 @@ DEFAULT_INPUT_TOKEN_BUDGET = 32_000
 # 2.48.0"). Send an honest, identifiable UA instead of spoofing a browser: a
 # browser UA that doesn't match the connection's TLS/HTTP2 fingerprint risks
 # being flagged as suspicious by stricter WAFs.
-_OUTBOUND_USER_AGENT = "StaffDeck/0.1.0 (+https://github.com/OpenBMB/StaffDeck)"
+_OUTBOUND_USER_AGENT = "StaffDeck/0.1.0"
 TURN_STAGE_MESSAGE_MARKER = "_agent_turn_message"
 class _CurrentStageText(str):
     pass

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -83,6 +83,12 @@ EMPTY_RESPONSE_RETRIES = 2
 EMPTY_RESPONSE_MESSAGE = "Model returned an empty response"
 DEFAULT_MODEL_API_TIMEOUT_SECONDS = 600.0
 DEFAULT_INPUT_TOKEN_BUDGET = 32_000
+# Some third-party OpenAI/Anthropic-compatible gateways run a WAF that blocks
+# requests carrying the official SDKs' default User-Agent (e.g. "OpenAI/Python
+# 2.48.0"). Send an honest, identifiable UA instead of spoofing a browser: a
+# browser UA that doesn't match the connection's TLS/HTTP2 fingerprint risks
+# being flagged as suspicious by stricter WAFs.
+_OUTBOUND_USER_AGENT = "StaffDeck/0.1.0 (+https://github.com/OpenBMB/StaffDeck)"
 TURN_STAGE_MESSAGE_MARKER = "_agent_turn_message"
 class _CurrentStageText(str):
     pass
@@ -110,6 +116,7 @@ class LLMClient:
                 api_key=api_key,
                 base_url=self.base_url,
                 timeout=self.timeout_seconds,
+                default_headers={"User-Agent": _OUTBOUND_USER_AGENT},
             )
             self.driver = ChatCompletionsDriver(self.client)
         elif protocol is ModelApiProtocol.OPENAI_RESPONSES:
@@ -117,6 +124,7 @@ class LLMClient:
                 api_key=api_key,
                 base_url=self.base_url,
                 timeout=self.timeout_seconds,
+                default_headers={"User-Agent": _OUTBOUND_USER_AGENT},
             )
             self.driver = OpenAIResponsesDriver(self.client)
         elif protocol is ModelApiProtocol.ANTHROPIC_MESSAGES:
@@ -124,6 +132,7 @@ class LLMClient:
                 "api_key": api_key,
                 "timeout": self.timeout_seconds,
                 "max_retries": 0,
+                "default_headers": {"User-Agent": _OUTBOUND_USER_AGENT},
             }
             if self.base_url:
                 # Anthropic's SDK always appends /v1/messages. If an operator
@@ -140,7 +149,10 @@ class LLMClient:
             self.client = Anthropic(**kwargs)
             self.driver = AnthropicMessagesDriver(self.client)
         elif protocol is ModelApiProtocol.GEMINI_GENERATE_CONTENT:
-            self.client = httpx.Client(timeout=self.timeout_seconds)
+            self.client = httpx.Client(
+                timeout=self.timeout_seconds,
+                headers={"User-Agent": _OUTBOUND_USER_AGENT},
+            )
             self.driver = GeminiGenerateContentDriver(
                 self.client,
                 self.base_url,

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -88,7 +88,7 @@ DEFAULT_INPUT_TOKEN_BUDGET = 32_000
 # 2.48.0"). Send an honest, identifiable UA instead of spoofing a browser: a
 # browser UA that doesn't match the connection's TLS/HTTP2 fingerprint risks
 # being flagged as suspicious by stricter WAFs.
-_OUTBOUND_USER_AGENT = "StaffDeck/0.1.0"
+_OUTBOUND_USER_AGENT = "StaffDeck"
 TURN_STAGE_MESSAGE_MARKER = "_agent_turn_message"
 class _CurrentStageText(str):
     pass

--- a/backend/tests/test_anthropic_driver.py
+++ b/backend/tests/test_anthropic_driver.py
@@ -312,6 +312,36 @@ def test_llm_client_adapts_anthropic_full_messages_endpoint(monkeypatch) -> None
     assert captured["base_url"] == "https://llm-center.modelbest.cn/llm"
 
 
+def test_llm_client_sets_outbound_user_agent_for_anthropic(monkeypatch) -> None:
+    from app.llm.client import _OUTBOUND_USER_AGENT
+
+    captured = {}
+
+    def fake_anthropic(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+        return SimpleNamespace(messages=_Messages())
+
+    monkeypatch.setattr("app.llm.client.decrypt_secret", lambda _value: "secret")
+    monkeypatch.setattr("app.llm.client.Anthropic", fake_anthropic)
+    config = SimpleNamespace(
+        api_protocol="anthropic_messages",
+        purpose="verification",
+        api_key_encrypted="encrypted",
+        base_url="https://api.anthropic.test",
+        model="claude-test",
+        temperature=0.2,
+        max_output_tokens=128,
+        protocol_options={},
+        legacy_extra_body={},
+    )
+
+    LLMClient(config)
+
+    assert captured["default_headers"]["User-Agent"] == _OUTBOUND_USER_AGENT
+    assert not any(key.startswith("X-Stainless") for key in captured["default_headers"])
+    assert captured["base_url"] == "https://api.anthropic.test"
+
+
 def test_locked_anthropic_sdk_uses_messages_wire_contract() -> None:
     captured = {}
 

--- a/backend/tests/test_gemini_driver.py
+++ b/backend/tests/test_gemini_driver.py
@@ -180,3 +180,30 @@ def test_llm_client_builds_gemini_driver(monkeypatch) -> None:
 
     assert isinstance(client.driver, GeminiGenerateContentDriver)
     assert client.driver.base_url == "https://llm-center.modelbest.cn/llm"
+
+
+def test_llm_client_sets_outbound_user_agent_for_gemini(monkeypatch) -> None:
+    from app.llm.client import _OUTBOUND_USER_AGENT
+
+    http_client = httpx.Client(transport=httpx.MockTransport(lambda _request: httpx.Response(200)))
+    captured = {}
+    monkeypatch.setattr("app.llm.client.decrypt_secret", lambda _value: "secret")
+    monkeypatch.setattr(
+        "app.llm.client.httpx.Client",
+        lambda **kwargs: captured.update(kwargs) or http_client,
+    )
+    config = SimpleNamespace(
+        api_protocol="gemini_generate_content",
+        purpose="verification",
+        api_key_encrypted="encrypted",
+        base_url="https://llm-center.modelbest.cn/llm",
+        model="gemini-2.5-flash",
+        temperature=0.2,
+        max_output_tokens=128,
+        protocol_options={},
+        legacy_extra_body={},
+    )
+
+    LLMClient(config)
+
+    assert captured["headers"]["User-Agent"] == _OUTBOUND_USER_AGENT

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -131,8 +131,8 @@ def test_llm_client_sets_outbound_user_agent_for_chat_completions(monkeypatch) -
         (),
         {
             "api_key_encrypted": "encrypted",
-            "base_url": "https://ytapi.ycflow.com/v1",
-            "model": "grok-4.6",
+            "base_url": "https://gateway.example.test/v1",
+            "model": "demo-model",
             "temperature": 0.2,
             "max_output_tokens": 128,
             "extra_body_json": {},

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -113,6 +113,38 @@ def test_llm_client_preserves_custom_openai_base_url(monkeypatch) -> None:
     assert captured["base_url"] == "https://custom-relay.example/llm"
 
 
+def test_llm_client_sets_outbound_user_agent_for_chat_completions(monkeypatch) -> None:
+    from app.llm.client import _OUTBOUND_USER_AGENT
+
+    captured = {}
+    monkeypatch.setattr("app.llm.client.decrypt_secret", lambda _value: "api-key")
+    monkeypatch.setattr(
+        "app.llm.client.OpenAI",
+        lambda **kwargs: captured.update(kwargs) or _FakeOpenAIClient(),
+    )
+    monkeypatch.setattr(
+        "app.llm.client.get_settings",
+        lambda: type("Settings", (), {"model_api_timeout_seconds": 30.0})(),
+    )
+    config = type(
+        "ModelConfig",
+        (),
+        {
+            "api_key_encrypted": "encrypted",
+            "base_url": "https://ytapi.ycflow.com/v1",
+            "model": "grok-4.6",
+            "temperature": 0.2,
+            "max_output_tokens": 128,
+            "extra_body_json": {},
+        },
+    )()
+
+    LLMClient(config)
+
+    assert captured["default_headers"]["User-Agent"] == _OUTBOUND_USER_AGENT
+    assert not any(key.startswith("X-Stainless") for key in captured["default_headers"])
+
+
 def test_model_config_create_defaults_to_8192_output_tokens():
     request = ModelConfigCreateRequest(
         tenant_id="tenant_demo",

--- a/backend/tests/test_openai_responses_driver.py
+++ b/backend/tests/test_openai_responses_driver.py
@@ -196,3 +196,34 @@ def test_llm_client_selects_responses_driver(monkeypatch) -> None:
         {"role": "system", "content": "system"},
         {"role": "user", "content": "ping"},
     ]
+
+
+def test_llm_client_sets_outbound_user_agent_for_responses(monkeypatch) -> None:
+    from app.llm.client import _OUTBOUND_USER_AGENT
+
+    fake_client = SimpleNamespace(responses=_Responses(response=None))
+    captured = {}
+    monkeypatch.setattr("app.llm.client.decrypt_secret", lambda _value: "secret")
+    monkeypatch.setattr(
+        "app.llm.client.OpenAI",
+        lambda **kwargs: captured.update(kwargs) or fake_client,
+    )
+    monkeypatch.setattr(
+        "app.llm.client.get_settings",
+        lambda: SimpleNamespace(model_api_timeout_seconds=30.0),
+    )
+    config = SimpleNamespace(
+        api_protocol="openai_responses",
+        api_key_encrypted="encrypted",
+        base_url="https://api.openai.com/v1",
+        model="gpt-test",
+        temperature=0.2,
+        max_output_tokens=128,
+        protocol_options={},
+        legacy_extra_body={},
+    )
+
+    LLMClient(config)
+
+    assert captured["default_headers"]["User-Agent"] == _OUTBOUND_USER_AGENT
+    assert not any(key.startswith("X-Stainless") for key in captured["default_headers"])


### PR DESCRIPTION
## Summary

Some third-party OpenAI/Anthropic-compatible gateways run a WAF that blocks
requests based on the outbound `User-Agent`. `LLMClient.__init__`
(`backend/app/llm/client.py`) never set a custom `User-Agent` on any of its
four protocol clients, so every request carried the official SDKs' default
UA — `openai==2.48.0` sends `OpenAI/Python 2.48.0`, `anthropic==0.117.1`
sends `Anthropic/Python 0.117.1` (both Stainless-generated, with a bundle
of `X-Stainless-*` fingerprint headers), and the bare `httpx.Client()` used
for Gemini sends httpx's own default UA.

Reproduced against a real third-party OpenAI-compatible relay gateway
(backed by Cloudflare): the default SDK UA is reliably blocked with an
HTTP 403 Cloudflare "Attention Required!" challenge page, while other
clients connect fine. An isolated check that strips only the
`X-Stainless-*` headers (leaving the default UA) is still blocked,
confirming the WAF keys off `User-Agent` alone.

Considered spoofing a browser UA to bypass the block, but rejected it: a
browser UA that doesn't match the connection's real TLS/HTTP2 fingerprint
risks being flagged as suspicious by stricter WAFs that cross-check the
two. Instead, this sends an honest, self-identifying UA: `StaffDeck`.
No version number is included — `pyproject.toml`'s `version` field has
never been bumped alongside an actual release (it's still `0.1.0` while
the project is tagged up to `v0.5.2`), so a hardcoded version would only
ever drift out of sync.

## Changes

- `backend/app/llm/client.py`: add module constant `_OUTBOUND_USER_AGENT`
  and set it via `default_headers={"User-Agent": ...}` on both `OpenAI(...)`
  constructions (`openai_chat_completions`, `openai_responses`) and the
  `Anthropic(...)` construction, and via `headers={"User-Agent": ...}` on
  the `httpx.Client(...)` used for `gemini_generate_content`. No other
  headers (including `X-Stainless-*`) are touched, and the existing
  Anthropic `/v1/messages`-suffix `base_url` rewrite logic is untouched.
- Added one regression test per protocol branch (chat completions,
  responses, Anthropic messages, Gemini) asserting the outbound
  `User-Agent` and that no `X-Stainless-*` header is touched.

## Testing

- `uv run pytest tests/ -q` — 2010 passed (worktree branch and after
  merging into local `main`).
- `uv run ruff check app` — pre-existing failures unrelated to this change
  (1608 findings across the codebase, e.g. `Optional[X]` vs `X | None`,
  import ordering in files this PR doesn't touch); `app/llm/client.py`'s
  only ruff finding is a pre-existing import-order issue that predates this
  change (verified against `HEAD` before editing). Flagging for separate
  cleanup, not addressed here to keep this PR scoped to the UA fix.
- Real-network verification against a real third-party OpenAI-compatible
  relay gateway using a throwaway local script (not committed) that
  mirrors the fixed `LLMClient.__init__` OpenAI-client construction:
  - Baseline (default SDK UA): 2/2 requests failed with HTTP 403 and a
    Cloudflare challenge-page body.
  - Fixed (custom UA): 3/3 requests succeeded with HTTP 200 and a real
    model response.

## Risks

No functional behavior change beyond the outbound header. Out of scope,
noted for follow-up but not touched here (per the task boundary): the
`frontend-enterprise/src/api/client.ts` / `apiErrorMessages.ts` /
`ModelsPage.tsx` and `backend/app/llm/protocol_drivers.py`
`_safe_upstream_body()` work is being handled in a separate branch/PR.
