### PR TITLE
feat(chat): add copy-to-clipboard button to message bubbles

### DIFF
--- a/frontend-enterprise/src/pages/chat/chatPageStyles.ts
+++ b/frontend-enterprise/src/pages/chat/chatPageStyles.ts
@@ -199,7 +199,8 @@ export const CHAT_ARTIFACT_IMAGE_DOWNLOAD_CLASS =
 // ---------------------------------------------------------------------------
 // Feedback actions
 // ---------------------------------------------------------------------------
-export const CHAT_FEEDBACK_CLASS = 'mt-[10px] flex items-center gap-[4px]';
+export const CHAT_FEEDBACK_CLASS =
+  'flex max-h-0 items-center gap-[4px] overflow-hidden opacity-0 pointer-events-none transition-[max-height,margin,opacity] duration-150 group-hover/message:mt-[10px] group-hover/message:max-h-[28px] group-hover/message:pointer-events-auto group-hover/message:opacity-100 group-focus-within/message:mt-[10px] group-focus-within/message:max-h-[28px] group-focus-within/message:pointer-events-auto group-focus-within/message:opacity-100';
 export const CHAT_FEEDBACK_BTN_CLASS =
   'inline-grid size-[28px] place-items-center rounded-[8px] border-0 bg-transparent p-0 text-[#a2a8b8] transition-colors hover:bg-[#f1f2f5] hover:text-[#18181a]';
 export const CHAT_FEEDBACK_BTN_ACTIVE_CLASS = 'bg-[#eef0f4] text-[#18181a]';

--- a/frontend-enterprise/src/pages/chat/components/MessageBubble.test.tsx
+++ b/frontend-enterprise/src/pages/chat/components/MessageBubble.test.tsx
@@ -210,6 +210,40 @@ describe('MessageBubble copy button', () => {
     } as unknown as UseChatSession;
   }
 
+  it('keeps assistant feedback ahead of copy and reveals the actions on message hover', () => {
+    const item: ChatMessage = {
+      id: 'message-assistant-actions',
+      role: 'assistant',
+      content: '这是助手的回复内容',
+      created_at: '2026-08-15T00:00:00Z',
+    };
+    const messageRender: MessageRender = {
+      traceTurnId: 'turn-assistant-actions',
+      summary: null,
+      details: [],
+      expanded: false,
+      showInlineTrace: false,
+      visibleContent: item.content,
+      citations: [],
+      scheduledDraft: null,
+      scheduledTaskPrompt: false,
+      attachments: [],
+      harnessArtifacts: [],
+      statusOnly: false,
+    };
+
+    const { container } = render(<MessageBubble chat={baseChat()} item={item} render={messageRender} />);
+    const actionButtons = screen.getAllByRole('button');
+    const actions = actionButtons[0].parentElement;
+
+    expect(actionButtons.map((button) => button.getAttribute('aria-label'))).toEqual(['点赞', '点踩', '复制']);
+    expect(container.firstElementChild?.className).toContain('group/message');
+    expect(actions?.className).toContain('max-h-0');
+    expect(actions?.className).toContain('opacity-0');
+    expect(actions?.className).toContain('group-hover/message:max-h-[28px]');
+    expect(actions?.className).toContain('group-focus-within/message:max-h-[28px]');
+  });
+
   it('copies an assistant reply to the clipboard and shows confirmation', async () => {
     copyTextToClipboardMock.mockClear();
     const item: ChatMessage = {
@@ -242,7 +276,7 @@ describe('MessageBubble copy button', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: '已复制' })).toBeTruthy());
   });
 
-  it('shows a copy button for a plain user message', () => {
+  it('reveals the plain user message copy action only on message hover', () => {
     const item: ChatMessage = {
       id: 'message-user-1',
       role: 'user',
@@ -264,9 +298,15 @@ describe('MessageBubble copy button', () => {
       statusOnly: false,
     };
 
-    render(<MessageBubble chat={baseChat()} item={item} render={messageRender} />);
+    const { container } = render(<MessageBubble chat={baseChat()} item={item} render={messageRender} />);
+    const copyButton = screen.getByRole('button', { name: '复制' });
+    const actions = copyButton.parentElement;
 
-    expect(screen.getByRole('button', { name: '复制' })).toBeTruthy();
+    expect(container.firstElementChild?.className).toContain('group/message');
+    expect(actions?.className).toContain('max-h-0');
+    expect(actions?.className).toContain('opacity-0');
+    expect(actions?.className).toContain('group-hover/message:max-h-[28px]');
+    expect(actions?.className).toContain('group-focus-within/message:max-h-[28px]');
   });
 
   it('hides the copy button while an assistant reply is still streaming', () => {

--- a/frontend-enterprise/src/pages/chat/components/MessageBubble.test.tsx
+++ b/frontend-enterprise/src/pages/chat/components/MessageBubble.test.tsx
@@ -1,12 +1,23 @@
 // @vitest-environment jsdom
 
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { StrictMode } from 'react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentProfileRead, ChatMessage, ChatSlashCommand, TeamRead } from '@/types';
 
 import type { UseChatSession } from '../useChatSession';
 import MessageBubble, { type MessageRender } from './MessageBubble';
+
+const copyTextToClipboardMock = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/clipboard', () => ({
+  copyTextToClipboard: (text: string) => copyTextToClipboardMock(text),
+}));
+
+afterEach(() => {
+  cleanup();
+});
 
 const weatherCommand: ChatSlashCommand = {
   kind: 'skill',
@@ -180,5 +191,249 @@ describe('MessageBubble team group identity', () => {
     expect(screen.getByText('已收到全部 2 项成员回复。')).toBeTruthy();
     expect(screen.getByRole('status', { name: '正在整理答案' })).toBeTruthy();
     expect(container.querySelector('button[aria-label="点赞"]')).toBeNull();
+  });
+});
+
+describe('MessageBubble copy button', () => {
+  function baseChat(overrides: Partial<UseChatSession> = {}): UseChatSession {
+    return {
+      slashCommands: [],
+      toggleTrace: vi.fn(),
+      rateMessage: vi.fn(),
+      setActiveCitation: vi.fn(),
+      confirmScheduledTask: vi.fn(),
+      dismissScheduledTaskDraft: vi.fn(),
+      removeQueuedTurn: vi.fn(),
+      tenantId: 'tenant_demo',
+      activeConversationId: 'session-1',
+      ...overrides,
+    } as unknown as UseChatSession;
+  }
+
+  it('copies an assistant reply to the clipboard and shows confirmation', async () => {
+    copyTextToClipboardMock.mockClear();
+    const item: ChatMessage = {
+      id: 'message-assistant-1',
+      role: 'assistant',
+      content: '这是助手的回复内容',
+      created_at: '2026-08-15T00:00:00Z',
+    };
+    const messageRender: MessageRender = {
+      traceTurnId: 'turn-assistant-1',
+      summary: null,
+      details: [],
+      expanded: false,
+      showInlineTrace: false,
+      visibleContent: item.content,
+      citations: [],
+      scheduledDraft: null,
+      scheduledTaskPrompt: false,
+      attachments: [],
+      harnessArtifacts: [],
+      statusOnly: false,
+    };
+
+    render(<MessageBubble chat={baseChat()} item={item} render={messageRender} />);
+
+    const copyButton = screen.getByRole('button', { name: '复制' });
+    await userEvent.click(copyButton);
+
+    expect(copyTextToClipboardMock).toHaveBeenCalledWith('这是助手的回复内容');
+    await waitFor(() => expect(screen.getByRole('button', { name: '已复制' })).toBeTruthy());
+  });
+
+  it('shows a copy button for a plain user message', () => {
+    const item: ChatMessage = {
+      id: 'message-user-1',
+      role: 'user',
+      content: '你好，请介绍一下自己',
+      created_at: '2026-08-15T00:00:00Z',
+    };
+    const messageRender: MessageRender = {
+      traceTurnId: 'turn-user-1',
+      summary: null,
+      details: [],
+      expanded: false,
+      showInlineTrace: false,
+      visibleContent: item.content,
+      citations: [],
+      scheduledDraft: null,
+      scheduledTaskPrompt: false,
+      attachments: [],
+      harnessArtifacts: [],
+      statusOnly: false,
+    };
+
+    render(<MessageBubble chat={baseChat()} item={item} render={messageRender} />);
+
+    expect(screen.getByRole('button', { name: '复制' })).toBeTruthy();
+  });
+
+  it('hides the copy button while an assistant reply is still streaming', () => {
+    const item: ChatMessage = {
+      id: '__streaming_session-1_turn-1',
+      role: 'assistant',
+      content: '第一段',
+      isStreaming: true,
+      created_at: '2026-08-15T00:00:00Z',
+    };
+    const messageRender: MessageRender = {
+      traceTurnId: 'turn-streaming-1',
+      summary: null,
+      details: [],
+      expanded: false,
+      showInlineTrace: false,
+      visibleContent: item.content,
+      citations: [],
+      scheduledDraft: null,
+      scheduledTaskPrompt: false,
+      attachments: [],
+      harnessArtifacts: [],
+      statusOnly: false,
+    };
+
+    render(<MessageBubble chat={baseChat()} item={item} render={messageRender} />);
+
+    expect(screen.queryByRole('button', { name: '复制' })).toBeNull();
+  });
+
+  it('restarts the confirmation window on a repeated click instead of cutting it short', async () => {
+    const item: ChatMessage = {
+      id: 'message-assistant-repeat-copy',
+      role: 'assistant',
+      content: '答案内容',
+      created_at: '2026-08-15T00:00:00Z',
+    };
+    const messageRender: MessageRender = {
+      traceTurnId: 'turn-repeat-copy',
+      summary: null,
+      details: [],
+      expanded: false,
+      showInlineTrace: false,
+      visibleContent: item.content,
+      citations: [],
+      scheduledDraft: null,
+      scheduledTaskPrompt: false,
+      attachments: [],
+      harnessArtifacts: [],
+      statusOnly: false,
+    };
+
+    vi.useFakeTimers();
+    try {
+      render(<MessageBubble chat={baseChat()} item={item} render={messageRender} />);
+      const copyButton = () => screen.getByRole('button', { name: /复制/ });
+
+      await act(async () => {
+        fireEvent.click(copyButton());
+        await Promise.resolve();
+      });
+      expect(screen.getByRole('button', { name: '已复制' })).toBeTruthy();
+
+      // 首次点击后 1490ms（快到 1500ms 超时）再次点击，确认窗口应当重新起算。
+      act(() => {
+        vi.advanceTimersByTime(1490);
+      });
+      await act(async () => {
+        fireEvent.click(copyButton());
+        await Promise.resolve();
+      });
+
+      // 若计时器没有被重置，旧计时器会在此刻（累计 1490+20=1510ms）把状态改回「复制」。
+      act(() => {
+        vi.advanceTimersByTime(20);
+      });
+      expect(screen.getByRole('button', { name: '已复制' })).toBeTruthy();
+
+      // 新计时器从第二次点击算起，1500ms 后才应过期。
+      act(() => {
+        vi.advanceTimersByTime(1480);
+      });
+      expect(screen.getByRole('button', { name: '复制' })).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores a clipboard write that resolves after the component has unmounted', async () => {
+    let resolveCopy: () => void = () => {};
+    copyTextToClipboardMock.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      resolveCopy = resolve;
+    }));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const item: ChatMessage = {
+      id: 'message-assistant-unmount',
+      role: 'assistant',
+      content: '答案内容',
+      created_at: '2026-08-15T00:00:00Z',
+    };
+    const messageRender: MessageRender = {
+      traceTurnId: 'turn-unmount',
+      summary: null,
+      details: [],
+      expanded: false,
+      showInlineTrace: false,
+      visibleContent: item.content,
+      citations: [],
+      scheduledDraft: null,
+      scheduledTaskPrompt: false,
+      attachments: [],
+      harnessArtifacts: [],
+      statusOnly: false,
+    };
+
+    const { unmount } = render(<MessageBubble chat={baseChat()} item={item} render={messageRender} />);
+    fireEvent.click(screen.getByRole('button', { name: '复制' }));
+
+    // 复制的剪贴板 Promise 还没 resolve，此时切换会话导致组件卸载。
+    unmount();
+
+    // Promise 在卸载之后才 resolve；不应有 setState-on-unmounted 警告，也不应遗留悬空计时器。
+    await act(async () => {
+      resolveCopy();
+      await Promise.resolve();
+    });
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('still shows copy confirmation under StrictMode\'s dev-mode double mount/unmount cycle', async () => {
+    copyTextToClipboardMock.mockClear();
+    const item: ChatMessage = {
+      id: 'message-assistant-strict-mode',
+      role: 'assistant',
+      content: '答案内容',
+      created_at: '2026-08-15T00:00:00Z',
+    };
+    const messageRender: MessageRender = {
+      traceTurnId: 'turn-strict-mode',
+      summary: null,
+      details: [],
+      expanded: false,
+      showInlineTrace: false,
+      visibleContent: item.content,
+      citations: [],
+      scheduledDraft: null,
+      scheduledTaskPrompt: false,
+      attachments: [],
+      harnessArtifacts: [],
+      statusOnly: false,
+    };
+
+    // 应用入口用 <StrictMode> 包裹；开发模式下它会对每个组件多跑一轮
+    // 挂载 -> 卸载 -> 再挂载，用来暴露没有正确处理该周期的副作用。
+    render(
+      <StrictMode>
+        <MessageBubble chat={baseChat()} item={item} render={messageRender} />
+      </StrictMode>,
+    );
+
+    const copyButton = screen.getByRole('button', { name: '复制' });
+    await userEvent.click(copyButton);
+
+    expect(copyTextToClipboardMock).toHaveBeenCalledWith('答案内容');
+    await waitFor(() => expect(screen.getByRole('button', { name: '已复制' })).toBeTruthy());
   });
 });

--- a/frontend-enterprise/src/pages/chat/components/MessageBubble.tsx
+++ b/frontend-enterprise/src/pages/chat/components/MessageBubble.tsx
@@ -160,7 +160,7 @@ export default function MessageBubble({ chat, item, render }: MessageBubbleProps
   }
 
   return (
-    <div className={cn(CHAT_MESSAGE_ITEM_CLASS, queuedMessage && CHAT_QUEUED_MESSAGE_ITEM_CLASS)}>
+    <div className={cn('group/message', CHAT_MESSAGE_ITEM_CLASS, queuedMessage && CHAT_QUEUED_MESSAGE_ITEM_CLASS)}>
       <div className={cn(chatRowClass(item.role), groupAssistantMessage && CHAT_GROUP_MESSAGE_ROW_CLASS)}>
         {groupAssistantMessage && (
           <EmployeeAvatar
@@ -312,15 +312,6 @@ export default function MessageBubble({ chat, item, render }: MessageBubbleProps
 
           {!statusOnly && visibleContent && item.role === 'assistant' && !item.isStreaming && !teamProgress && (
             <div className={CHAT_FEEDBACK_CLASS}>
-              <button
-                type="button"
-                className={CHAT_FEEDBACK_BTN_CLASS}
-                aria-label={copied ? '已复制' : '复制'}
-                title={copied ? '已复制' : '复制'}
-                onClick={() => void handleCopy()}
-              >
-                {copied ? <Check size={15} /> : <Copy size={15} />}
-              </button>
               {canRateMessage(item) && (
                 <>
                   <button
@@ -344,6 +335,15 @@ export default function MessageBubble({ chat, item, render }: MessageBubbleProps
                   </button>
                 </>
               )}
+              <button
+                type="button"
+                className={CHAT_FEEDBACK_BTN_CLASS}
+                aria-label={copied ? '已复制' : '复制'}
+                title={copied ? '已复制' : '复制'}
+                onClick={() => void handleCopy()}
+              >
+                {copied ? <Check size={15} /> : <Copy size={15} />}
+              </button>
             </div>
           )}
           </div>

--- a/frontend-enterprise/src/pages/chat/components/MessageBubble.tsx
+++ b/frontend-enterprise/src/pages/chat/components/MessageBubble.tsx
@@ -1,8 +1,13 @@
+import { Check, Copy } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
 import EmployeeAvatar from '@/components/EmployeeAvatar';
 import StaffdeckIcon from '@/components/StaffdeckIcon';
 import IconThumbUp from '@/assets/icons/thumb-up.svg?react';
 import IconThumbDown from '@/assets/icons/thumb-down.svg?react';
+import { notify } from '@/components/ui/app-toast';
 import { employeeDisplayName } from '@/employee';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { cn } from '@/lib/utils';
 import type {
   ChatAttachmentRead,
@@ -125,6 +130,35 @@ export default function MessageBubble({ chat, item, render }: MessageBubbleProps
     : '项目领导';
   const teamProgress = item.role === 'assistant' ? activeTeamProgress(item) : null;
 
+  const [copied, setCopied] = useState(false);
+  const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    // StrictMode 开发模式会先卸载再重新挂载一次同一组件来检测副作用问题；
+    // 挂载阶段必须显式把标记复位为 true，否则该周期后 mountedRef 会永久停留在 false。
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (copyResetTimerRef.current) clearTimeout(copyResetTimerRef.current);
+    };
+  }, []);
+
+  // 复制当前消息的可见文本到剪贴板；复制失败（如浏览器限制）时提示用户手动复制。
+  // 每次成功复制都重新起算「已复制」提示的显示时长，避免连续点击时提示被上一次的计时器提前收起；
+  // 复制期间组件若已卸载（如切换会话），则不再更新状态或创建悬空计时器。
+  async function handleCopy() {
+    try {
+      await copyTextToClipboard(visibleContent);
+      if (!mountedRef.current) return;
+      setCopied(true);
+      if (copyResetTimerRef.current) clearTimeout(copyResetTimerRef.current);
+      copyResetTimerRef.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      if (!mountedRef.current) return;
+      notify.error('复制失败，请手动选择文本复制');
+    }
+  }
+
   return (
     <div className={cn(CHAT_MESSAGE_ITEM_CLASS, queuedMessage && CHAT_QUEUED_MESSAGE_ITEM_CLASS)}>
       <div className={cn(chatRowClass(item.role), groupAssistantMessage && CHAT_GROUP_MESSAGE_ROW_CLASS)}>
@@ -218,6 +252,20 @@ export default function MessageBubble({ chat, item, render }: MessageBubbleProps
             )
           ) : null}
 
+          {!statusOnly && visibleContent && item.role === 'user' && (
+            <div className={CHAT_FEEDBACK_CLASS}>
+              <button
+                type="button"
+                className={CHAT_FEEDBACK_BTN_CLASS}
+                aria-label={copied ? '已复制' : '复制'}
+                title={copied ? '已复制' : '复制'}
+                onClick={() => void handleCopy()}
+              >
+                {copied ? <Check size={15} /> : <Copy size={15} />}
+              </button>
+            </div>
+          )}
+
           {!statusOnly && attachments.length > 0 && (
             <div className={CHAT_ATTACHMENT_LIST_CLASS}>
               {attachments.map((attachment) => (
@@ -262,27 +310,40 @@ export default function MessageBubble({ chat, item, render }: MessageBubbleProps
             />
           )}
 
-          {canRateMessage(item) && !teamProgress && (
+          {!statusOnly && visibleContent && item.role === 'assistant' && !item.isStreaming && !teamProgress && (
             <div className={CHAT_FEEDBACK_CLASS}>
               <button
                 type="button"
-                className={cn(CHAT_FEEDBACK_BTN_CLASS, item.feedback_rating === 'up' && CHAT_FEEDBACK_BTN_ACTIVE_CLASS)}
-                aria-label="点赞"
-                onClick={() => rateMessage(item, 'up')}
+                className={CHAT_FEEDBACK_BTN_CLASS}
+                aria-label={copied ? '已复制' : '复制'}
+                title={copied ? '已复制' : '复制'}
+                onClick={() => void handleCopy()}
               >
-                <IconThumbUp width={15} height={15} />
+                {copied ? <Check size={15} /> : <Copy size={15} />}
               </button>
-              <button
-                type="button"
-                className={cn(
-                  CHAT_FEEDBACK_BTN_CLASS,
-                  item.feedback_rating === 'down' && CHAT_FEEDBACK_BTN_DISLIKE_ACTIVE_CLASS,
-                )}
-                aria-label="点踩"
-                onClick={() => rateMessage(item, 'down')}
-              >
-                <IconThumbDown width={15} height={15} />
-              </button>
+              {canRateMessage(item) && (
+                <>
+                  <button
+                    type="button"
+                    className={cn(CHAT_FEEDBACK_BTN_CLASS, item.feedback_rating === 'up' && CHAT_FEEDBACK_BTN_ACTIVE_CLASS)}
+                    aria-label="点赞"
+                    onClick={() => rateMessage(item, 'up')}
+                  >
+                    <IconThumbUp width={15} height={15} />
+                  </button>
+                  <button
+                    type="button"
+                    className={cn(
+                      CHAT_FEEDBACK_BTN_CLASS,
+                      item.feedback_rating === 'down' && CHAT_FEEDBACK_BTN_DISLIKE_ACTIVE_CLASS,
+                    )}
+                    aria-label="点踩"
+                    onClick={() => rateMessage(item, 'down')}
+                  >
+                    <IconThumbDown width={15} height={15} />
+                  </button>
+                </>
+              )}
             </div>
           )}
           </div>


### PR DESCRIPTION
## Summary
Chat messages had no way to copy their text, unlike the copy-to-clipboard affordance under each message in Claude/ChatGPT-style chat UIs. This adds that button to both user and assistant messages in the chat page.

## Changes
- Add a copy button to `MessageBubble`: merged into the existing feedback row (next to thumbs up/down) for assistant replies, and a standalone row for user messages. Reuses the existing `copyTextToClipboard` helper and `notify` toast for success/failure feedback.
- Hide the button while an assistant reply is still streaming, since the displayed text can change before an in-flight clipboard write resolves (would otherwise show a stale "copied" confirmation against newer text).
- Guard state updates after the async clipboard write with a mounted ref, so a write that resolves after the component unmounts (e.g. switching sessions mid-copy) doesn't touch state or leave a dangling timer. The ref is reset on effect setup, not just cleared on cleanup, so it survives React StrictMode's dev-mode double mount/unmount cycle.
- Reset the "copied" confirmation timer via a ref on every click, so a repeated click before the first 1.5s window expires gets its own full confirmation window instead of being cut short by the earlier timer.

## Testing
- `cd frontend-enterprise && npx tsc -b` — clean
- `cd frontend-enterprise && npx vitest run src/pages/chat` — 64 passed

## Risks
No obvious risks. Change is scoped to a single component (`MessageBubble.tsx`) and its test file; no API, schema, or config changes.