### PR TITLE
fix(api-keys): restore disable and add deletion

### DIFF
--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -309,6 +309,22 @@ def revoke_agent_api_credential(
     return _agent_api_credential_read(row)
 
 
+@enterprise_router.delete("/{agent_id}/api-credentials/{credential_id}", status_code=204)
+def delete_agent_api_credential(
+    agent_id: str,
+    credential_id: str,
+    tenant_id: str = Query(...),
+    db: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    """永久删除当前用户有管理权的员工 API 密钥。"""
+    agent = _get_agent(db, tenant_id, agent_id)
+    _ensure_can_manage_agent(agent, current_user)
+    row = _get_agent_api_credential(db, tenant_id, agent_id, credential_id)
+    db.delete(row)
+    db.commit()
+
+
 @enterprise_router.get("/{agent_id}/work-record", response_model=AgentWorkRecordRead)
 def get_agent_work_record(
     agent_id: str,

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -417,6 +417,20 @@ def revoke_account_api_credential(
     return _account_api_credential_read(row, current_user.id)
 
 
+@router.delete("/me/api-credentials/{credential_id}", status_code=204)
+def delete_account_api_credential(
+    credential_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_session),
+) -> None:
+    """永久删除当前账号拥有的 API 密钥。"""
+    row = _get_account_api_credential(
+        db, current_user.tenant_id, current_user.id, credential_id
+    )
+    db.delete(row)
+    db.commit()
+
+
 @router.put("/users/{user_id}", response_model=UserRead)
 def update_user(
     user_id: str,

--- a/backend/tests/test_public_api_v1.py
+++ b/backend/tests/test_public_api_v1.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine, select
@@ -24,6 +26,7 @@ from app.db.models import (
 )
 from app.api.agents import (
     create_agent_api_credential,
+    delete_agent_api_credential,
     list_agent_api_credentials,
     revoke_agent_api_credential,
     rotate_agent_api_credential,
@@ -31,6 +34,7 @@ from app.api.agents import (
 from app.api.auth import (
     AccountAPICredentialCreateRequest,
     create_account_api_credential,
+    delete_account_api_credential,
     list_account_api_credentials,
     revoke_account_api_credential,
     rotate_account_api_credential,
@@ -775,6 +779,62 @@ def test_employee_settings_manage_runtime_keys(monkeypatch) -> None:
             "agent_api", created.id, "tenant_api", db, admin
         )
         assert revoked.status == "revoked"
+
+
+def test_api_credential_deletion_is_scoped_and_invalidates_tokens(monkeypatch) -> None:
+    client, engine, _admin_token = _client(monkeypatch)
+    with Session(engine) as db:
+        admin = db.get(User, "user_api_admin")
+        assert admin is not None
+        outsider = User(
+            id="user_api_outsider",
+            tenant_id="tenant_api",
+            username="api_outsider",
+            role="member",
+            password_hash="x",
+        )
+        db.add(outsider)
+        db.commit()
+
+        employee_credential = create_agent_api_credential(
+            "agent_api",
+            AgentAPICredentialCreateRequest(
+                tenant_id="tenant_api",
+                name="待删除员工密钥",
+                access="runtime",
+            ),
+            db,
+            admin,
+        )
+        account_credential = create_account_api_credential(
+            AccountAPICredentialCreateRequest(name="待删除账号密钥"),
+            admin,
+            db,
+        )
+
+        with pytest.raises(HTTPException, match="Only the creator or administrator") as forbidden:
+            delete_agent_api_credential(
+                "agent_api", employee_credential.id, "tenant_api", db, outsider
+            )
+        assert forbidden.value.status_code == 403
+
+        with pytest.raises(HTTPException, match="Account API credential not found") as missing:
+            delete_account_api_credential(account_credential.id, outsider, db)
+        assert missing.value.status_code == 404
+
+        delete_agent_api_credential(
+            "agent_api", employee_credential.id, "tenant_api", db, admin
+        )
+        assert db.get(APICredential, employee_credential.id) is None
+
+        delete_account_api_credential(account_credential.id, admin, db)
+        assert db.get(APICredential, account_credential.id) is None
+
+    response = client.get(
+        "/agents",
+        headers={"Authorization": f"Bearer {account_credential.api_key}"},
+    )
+    assert response.status_code == 401
 
 
 def test_account_master_key_follows_user_visible_agents(monkeypatch) -> None:

--- a/frontend-enterprise/src/components/AccountApiKeyDialog.test.tsx
+++ b/frontend-enterprise/src/components/AccountApiKeyDialog.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import AccountApiKeyDialog from './AccountApiKeyDialog';
+
+/** 构造客户端请求所需的成功 JSON 响应。 */
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+/** 模拟账户密钥生命周期接口，并让刷新请求返回最新状态。 */
+function stubAccountCredentialFetch() {
+  let status = 'active';
+  let exists = true;
+  const credential = () => ({
+    id: 'account-key-1',
+    user_id: 'user-1',
+    name: '账户密钥',
+    access: 'user_full_access',
+    key_prefix: 'sd_live_test…',
+    scopes: ['runs:*'],
+    status,
+    created_at: '2026-08-29T00:00:00Z',
+  });
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (init?.method === 'POST' && url.endsWith('/api/auth/me/api-credentials/account-key-1/revoke')) {
+      status = 'revoked';
+      return jsonResponse(credential());
+    }
+    if (init?.method === 'DELETE' && url.endsWith('/api/auth/me/api-credentials/account-key-1')) {
+      exists = false;
+      return jsonResponse({});
+    }
+    if (url.endsWith('/api/auth/me/api-credentials')) return jsonResponse(exists ? [credential()] : []);
+    return jsonResponse({});
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('AccountApiKeyDialog', () => {
+  it('uses an in-application confirmation before revoking an account credential', async () => {
+    const user = userEvent.setup();
+    const fetchMock = stubAccountCredentialFetch();
+
+    render(
+      <AccountApiKeyDialog
+        account={{ id: 'user-1', username: 'admin', role: 'admin' }}
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByText('账户密钥');
+    await user.click(screen.getByRole('button', { name: '禁用' }));
+    expect(await screen.findByText('确认禁用 API 密钥')).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: '确认禁用' }));
+
+    await waitFor(() => expect(screen.getByText('已禁用')).toBeTruthy());
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/me/api-credentials/account-key-1/revoke',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('cancels or permanently deletes an account credential only after confirmation', async () => {
+    const user = userEvent.setup();
+    const fetchMock = stubAccountCredentialFetch();
+
+    render(
+      <AccountApiKeyDialog
+        account={{ id: 'user-1', username: 'admin', role: 'admin' }}
+        open
+        onClose={vi.fn()}
+      />,
+    );
+
+    await screen.findByText('账户密钥');
+    await user.click(screen.getByRole('button', { name: '删除' }));
+    expect(await screen.findByText('确认删除 API 密钥')).toBeTruthy();
+    expect(screen.getByText(/删除后无法恢复/)).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: '取消' }));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('账户密钥')).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: '删除' }));
+    await user.click(screen.getByRole('button', { name: '永久删除' }));
+
+    await waitFor(() => expect(screen.queryByText('账户密钥')).toBeNull());
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/me/api-credentials/account-key-1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});

--- a/frontend-enterprise/src/components/AccountApiKeyDialog.tsx
+++ b/frontend-enterprise/src/components/AccountApiKeyDialog.tsx
@@ -15,12 +15,14 @@ import {
   LoaderCircle,
   RefreshCw,
   ShieldCheck,
+  Trash2,
   UsersRound,
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { api } from '../api/client';
 import { copyTextToClipboard } from '../lib/clipboard';
+import { ConfirmDialog } from './ConfirmDialog';
 
 export type AccountApiKeySubject = {
   id: string;
@@ -45,6 +47,7 @@ type AccountApiCredential = {
 
 type AccountApiCredentialCreated = AccountApiCredential & { api_key: string };
 
+/** 展示并管理当前账户 API 密钥的创建、轮换、禁用和删除操作。 */
 export default function AccountApiKeyDialog({
   account,
   open,
@@ -58,6 +61,8 @@ export default function AccountApiKeyDialog({
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
   const [actingId, setActingId] = useState<string | null>(null);
+  const [pendingRevoke, setPendingRevoke] = useState<AccountApiCredential | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<AccountApiCredential | null>(null);
   const [revealed, setRevealed] = useState<AccountApiCredentialCreated | null>(null);
   const [copied, setCopied] = useState(false);
   const revealedKeyRef = useRef<HTMLInputElement | null>(null);
@@ -128,8 +133,9 @@ export default function AccountApiKeyDialog({
     }
   }
 
+  /** 在用户已明确确认后禁用指定账户密钥，并刷新列表中的持久化状态。 */
   async function revokeCredential(row: AccountApiCredential) {
-    if (!account || !window.confirm(`确认禁用「${row.name}」？禁用后调用会立即失败。`)) return;
+    if (!account) return;
     setActingId(row.id);
     try {
       await api.post(
@@ -143,6 +149,24 @@ export default function AccountApiKeyDialog({
       notify.error(error instanceof Error ? error.message : '禁用账号 API 密钥失败');
     } finally {
       setActingId(null);
+      setPendingRevoke(null);
+    }
+  }
+
+  /** 在用户已明确确认后永久删除指定账户密钥，并移除可能展示的明文。 */
+  async function deleteCredential(row: AccountApiCredential) {
+    if (!account) return;
+    setActingId(row.id);
+    try {
+      await api.delete(`/api/auth/me/api-credentials/${encodeURIComponent(row.id)}`);
+      if (revealed?.id === row.id) setRevealed(null);
+      await load();
+      notify.success('账号 API 密钥已永久删除');
+    } catch (error) {
+      notify.error(error instanceof Error ? error.message : '删除账号 API 密钥失败');
+    } finally {
+      setActingId(null);
+      setPendingDelete(null);
     }
   }
 
@@ -161,7 +185,7 @@ export default function AccountApiKeyDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={(next) => { if (!next && !creating && !actingId) onClose(); }}>
+    <Dialog open={open} onOpenChange={(next) => { if (!next && !creating && !actingId && !pendingRevoke && !pendingDelete) onClose(); }}>
       <DialogContent
         aria-describedby="account-api-key-description"
         data-i18n-ignore
@@ -267,9 +291,13 @@ export default function AccountApiKeyDialog({
                       <RefreshCw className={actingId === row.id ? 'size-[12px] animate-spin' : 'size-[12px]'} />
                       轮换
                     </Button>
-                    <Button type="button" variant="outline" disabled={row.status !== 'active' || Boolean(actingId)} onClick={() => void revokeCredential(row)} className="h-[29px] rounded-[9px] border-[#f0d8d8] px-[9px] text-[10px] text-[#bd4141] hover:bg-[#fff1f1] hover:text-[#a62d2d]">
+                    <Button type="button" variant="outline" disabled={row.status !== 'active' || Boolean(actingId)} onClick={() => setPendingRevoke(row)} className="h-[29px] rounded-[9px] border-[#f0d8d8] px-[9px] text-[10px] text-[#bd4141] hover:bg-[#fff1f1] hover:text-[#a62d2d]">
                       <Ban className="size-[12px]" />
                       禁用
+                    </Button>
+                    <Button type="button" variant="outline" disabled={Boolean(actingId)} onClick={() => setPendingDelete(row)} className="h-[29px] rounded-[9px] border-[#f0d8d8] px-[9px] text-[10px] text-[#bd4141] hover:bg-[#fff1f1] hover:text-[#a62d2d]">
+                      <Trash2 className="size-[12px]" />
+                      删除
                     </Button>
                   </div>
                 </div>
@@ -283,6 +311,25 @@ export default function AccountApiKeyDialog({
           </section>
         </div>
       </DialogContent>
+      <ConfirmDialog
+        open={Boolean(pendingRevoke)}
+        onOpenChange={(next) => { if (!next && !actingId) setPendingRevoke(null); }}
+        title="确认禁用 API 密钥"
+        description={pendingRevoke ? `确认禁用「${pendingRevoke.name}」？禁用后调用会立即失败。` : undefined}
+        confirmText="确认禁用"
+        destructive={false}
+        loading={Boolean(actingId)}
+        onConfirm={() => { if (pendingRevoke) void revokeCredential(pendingRevoke); }}
+      />
+      <ConfirmDialog
+        open={Boolean(pendingDelete)}
+        onOpenChange={(next) => { if (!next && !actingId) setPendingDelete(null); }}
+        title="确认删除 API 密钥"
+        description={pendingDelete ? `确认永久删除「${pendingDelete.name}」？删除后无法恢复。` : undefined}
+        confirmText="永久删除"
+        loading={Boolean(actingId)}
+        onConfirm={() => { if (pendingDelete) void deleteCredential(pendingDelete); }}
+      />
     </Dialog>
   );
 }

--- a/frontend-enterprise/src/components/EmployeeApiKeyDialog.test.tsx
+++ b/frontend-enterprise/src/components/EmployeeApiKeyDialog.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentProfileRead } from '@/types';
+
+import EmployeeApiKeyDialog from './EmployeeApiKeyDialog';
+
+const agent: AgentProfileRead = {
+  id: 'agent-1',
+  tenant_id: 'tenant_demo',
+  name: '小艾',
+  is_overall: false,
+  status: 'active',
+  metadata: {},
+  resources: [],
+  created_at: '2026-08-29T00:00:00Z',
+  updated_at: '2026-08-29T00:00:00Z',
+};
+
+/** 构造客户端请求所需的成功 JSON 响应。 */
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+/** 模拟员工密钥生命周期接口，并让刷新请求返回最新状态。 */
+function stubEmployeeCredentialFetch() {
+  let status = 'active';
+  let exists = true;
+  const credential = () => ({
+    id: 'employee-key-1',
+    agent_id: agent.id,
+    name: '员工运行密钥',
+    access: 'runtime',
+    key_prefix: 'sd_live_test…',
+    scopes: ['runs:*'],
+    status,
+    created_at: '2026-08-29T00:00:00Z',
+  });
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      init?.method === 'POST'
+      && url.endsWith('/api/enterprise/agents/agent-1/api-credentials/employee-key-1/revoke?tenant_id=tenant_demo')
+    ) {
+      status = 'revoked';
+      return jsonResponse(credential());
+    }
+    if (
+      init?.method === 'DELETE'
+      && url.endsWith('/api/enterprise/agents/agent-1/api-credentials/employee-key-1?tenant_id=tenant_demo')
+    ) {
+      exists = false;
+      return jsonResponse({});
+    }
+    if (url.endsWith('/api/enterprise/agents/agent-1/api-credentials?tenant_id=tenant_demo')) {
+      return jsonResponse(exists ? [credential()] : []);
+    }
+    return jsonResponse({});
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('EmployeeApiKeyDialog', () => {
+  it('uses an in-application confirmation before revoking an employee credential', async () => {
+    const user = userEvent.setup();
+    const fetchMock = stubEmployeeCredentialFetch();
+
+    render(<EmployeeApiKeyDialog agent={agent} open onClose={vi.fn()} />);
+
+    await screen.findByText('员工运行密钥');
+    await user.click(screen.getByRole('button', { name: '禁用' }));
+    expect(await screen.findByText('确认禁用 API 密钥')).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: '确认禁用' }));
+
+    await waitFor(() => expect(screen.getByText('已禁用')).toBeTruthy());
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/enterprise/agents/agent-1/api-credentials/employee-key-1/revoke?tenant_id=tenant_demo',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('cancels or permanently deletes an employee credential only after confirmation', async () => {
+    const user = userEvent.setup();
+    const fetchMock = stubEmployeeCredentialFetch();
+
+    render(<EmployeeApiKeyDialog agent={agent} open onClose={vi.fn()} />);
+
+    await screen.findByText('员工运行密钥');
+    await user.click(screen.getByRole('button', { name: '删除' }));
+    expect(await screen.findByText('确认删除 API 密钥')).toBeTruthy();
+    expect(screen.getByText(/删除后无法恢复/)).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: '取消' }));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('员工运行密钥')).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: '删除' }));
+    await user.click(screen.getByRole('button', { name: '永久删除' }));
+
+    await waitFor(() => expect(screen.queryByText('员工运行密钥')).toBeNull());
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/enterprise/agents/agent-1/api-credentials/employee-key-1?tenant_id=tenant_demo',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});

--- a/frontend-enterprise/src/components/EmployeeApiKeyDialog.tsx
+++ b/frontend-enterprise/src/components/EmployeeApiKeyDialog.tsx
@@ -15,6 +15,7 @@ import {
   LoaderCircle,
   RefreshCw,
   TerminalSquare,
+  Trash2,
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -22,6 +23,7 @@ import { api, TENANT_ID } from '../api/client';
 import { employeeDisplayName } from '../employee';
 import { copyTextToClipboard } from '../lib/clipboard';
 import type { AgentProfileRead } from '../types';
+import { ConfirmDialog } from './ConfirmDialog';
 
 type KeyAccess = 'runtime';
 type CredentialAccess = KeyAccess | 'full_access';
@@ -56,6 +58,7 @@ function accessLabel(access: CredentialAccess): string {
   return access === 'full_access' ? '旧版员工全量密钥' : ACCESS_META.runtime.label;
 }
 
+/** 展示并管理指定员工 API 密钥的创建、轮换、禁用和删除操作。 */
 export default function EmployeeApiKeyDialog({
   agent,
   open,
@@ -69,6 +72,8 @@ export default function EmployeeApiKeyDialog({
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState<KeyAccess | null>(null);
   const [actingId, setActingId] = useState<string | null>(null);
+  const [pendingRevoke, setPendingRevoke] = useState<AgentApiCredential | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<AgentApiCredential | null>(null);
   const [revealed, setRevealed] = useState<AgentApiCredentialCreated | null>(null);
   const [copied, setCopied] = useState(false);
   const revealedKeyRef = useRef<HTMLInputElement | null>(null);
@@ -138,8 +143,9 @@ export default function EmployeeApiKeyDialog({
     }
   }
 
+  /** 在用户已明确确认后禁用指定员工密钥，并刷新列表中的持久化状态。 */
   async function revokeCredential(row: AgentApiCredential) {
-    if (!agent || !window.confirm(`确认禁用「${row.name}」？禁用后调用会立即失败。`)) return;
+    if (!agent) return;
     setActingId(row.id);
     try {
       await api.post(
@@ -153,6 +159,26 @@ export default function EmployeeApiKeyDialog({
       notify.error(error instanceof Error ? error.message : '禁用 API 密钥失败');
     } finally {
       setActingId(null);
+      setPendingRevoke(null);
+    }
+  }
+
+  /** 在用户已明确确认后永久删除指定员工密钥，并移除可能展示的明文。 */
+  async function deleteCredential(row: AgentApiCredential) {
+    if (!agent) return;
+    setActingId(row.id);
+    try {
+      await api.delete(
+        `/api/enterprise/agents/${encodeURIComponent(agent.id)}/api-credentials/${encodeURIComponent(row.id)}?tenant_id=${encodeURIComponent(TENANT_ID)}`,
+      );
+      if (revealed?.id === row.id) setRevealed(null);
+      await load();
+      notify.success('API 密钥已永久删除');
+    } catch (error) {
+      notify.error(error instanceof Error ? error.message : '删除 API 密钥失败');
+    } finally {
+      setActingId(null);
+      setPendingDelete(null);
     }
   }
 
@@ -171,7 +197,7 @@ export default function EmployeeApiKeyDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={(next) => { if (!next && !creating && !actingId) onClose(); }}>
+    <Dialog open={open} onOpenChange={(next) => { if (!next && !creating && !actingId && !pendingRevoke && !pendingDelete) onClose(); }}>
       <DialogContent
         aria-describedby="employee-api-key-description"
         data-i18n-ignore
@@ -285,9 +311,13 @@ export default function EmployeeApiKeyDialog({
                       <RefreshCw className={actingId === row.id ? 'size-[12px] animate-spin' : 'size-[12px]'} />
                       轮换
                     </Button>
-                    <Button type="button" variant="outline" disabled={row.status !== 'active' || Boolean(actingId)} onClick={() => void revokeCredential(row)} className="h-[29px] rounded-[9px] border-[#f0d8d8] px-[9px] text-[10px] text-[#bd4141] hover:bg-[#fff1f1] hover:text-[#a62d2d]">
+                    <Button type="button" variant="outline" disabled={row.status !== 'active' || Boolean(actingId)} onClick={() => setPendingRevoke(row)} className="h-[29px] rounded-[9px] border-[#f0d8d8] px-[9px] text-[10px] text-[#bd4141] hover:bg-[#fff1f1] hover:text-[#a62d2d]">
                       <Ban className="size-[12px]" />
                       禁用
+                    </Button>
+                    <Button type="button" variant="outline" disabled={Boolean(actingId)} onClick={() => setPendingDelete(row)} className="h-[29px] rounded-[9px] border-[#f0d8d8] px-[9px] text-[10px] text-[#bd4141] hover:bg-[#fff1f1] hover:text-[#a62d2d]">
+                      <Trash2 className="size-[12px]" />
+                      删除
                     </Button>
                   </div>
                 </div>
@@ -301,6 +331,25 @@ export default function EmployeeApiKeyDialog({
           </section>
         </div>
       </DialogContent>
+      <ConfirmDialog
+        open={Boolean(pendingRevoke)}
+        onOpenChange={(next) => { if (!next && !actingId) setPendingRevoke(null); }}
+        title="确认禁用 API 密钥"
+        description={pendingRevoke ? `确认禁用「${pendingRevoke.name}」？禁用后调用会立即失败。` : undefined}
+        confirmText="确认禁用"
+        destructive={false}
+        loading={Boolean(actingId)}
+        onConfirm={() => { if (pendingRevoke) void revokeCredential(pendingRevoke); }}
+      />
+      <ConfirmDialog
+        open={Boolean(pendingDelete)}
+        onOpenChange={(next) => { if (!next && !actingId) setPendingDelete(null); }}
+        title="确认删除 API 密钥"
+        description={pendingDelete ? `确认永久删除「${pendingDelete.name}」？删除后无法恢复。` : undefined}
+        confirmText="永久删除"
+        loading={Boolean(actingId)}
+        onConfirm={() => { if (pendingDelete) void deleteCredential(pendingDelete); }}
+      />
     </Dialog>
   );
 }


### PR DESCRIPTION
## Summary

Restores reliable in-app confirmation for API-key disable actions and adds scoped permanent deletion for account and employee API keys.

## Features

- Replaces native browser confirmations with the application confirmation dialog for API-key disable actions.
- Adds permanent-delete endpoints for account-owned keys and employee keys, preserving existing tenant and manager authorization checks.
- Adds a delete action to both API-key dialogs, clears any locally revealed key after deletion, and refreshes the persisted list state.
- Keeps dialogs open while a confirmation or key mutation is in progress to avoid interrupted destructive actions.

## Tests

- Adds API coverage for account and employee API-key deletion.
- Adds component coverage for disable and delete confirmation behavior.

## Validation

- Python: 18 targeted API tests passed.
- Frontend: 4 targeted component tests passed.
- Frontend production build passed.