### PR TITLE
feat(updates): make release source distributor-aware

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
       - name: Build
         env:
           VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+          STAFFDECK_RELEASE_REPOSITORY: ${{ github.repository }}
           STAFFDECK_MACOS_ARCH: ${{ matrix.macos_arch }}
         run: ${{ matrix.script }}
 

--- a/backend/app/api/app_updates.py
+++ b/backend/app/api/app_updates.py
@@ -11,28 +11,61 @@ from fastapi import APIRouter
 from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel
 
+from app.distribution import (
+    DEFAULT_RELEASE_REPOSITORY,
+    release_repository,
+    validate_release_repository,
+)
 from app.version import app_version, update_check_enabled
 
 router = APIRouter(prefix="/api/app", tags=["app"])
 
-RELEASES_FEED_URL = "https://github.com/OpenBMB/StaffDeck/releases.atom"
-RELEASES_PAGE_URL = "https://github.com/OpenBMB/StaffDeck/releases"
-RELEASE_TAG_PATH = "/OpenBMB/StaffDeck/releases/tag/"
 SUCCESS_CACHE_SECONDS = 6 * 60 * 60
 FAILURE_CACHE_SECONDS = 15 * 60
 
 _cache_lock = threading.Lock()
 
 
+@dataclass(frozen=True)
+class ReleaseSource:
+    """Trusted GitHub endpoints derived from one validated distribution identity."""
+
+    repository: str
+    feed_url: str
+    page_url: str
+    tag_path: str
+
+
+def _release_source(repository: str | None) -> ReleaseSource | None:
+    """Derive HTTPS GitHub release endpoints, returning None for an invalid identity."""
+    validated = validate_release_repository(repository)
+    if validated is None:
+        return None
+    return ReleaseSource(
+        repository=validated,
+        feed_url=f"https://github.com/{validated}/releases.atom",
+        page_url=f"https://github.com/{validated}/releases",
+        tag_path=f"/{validated}/releases/tag/",
+    )
+
+
+_DEFAULT_RELEASE_SOURCE = _release_source(DEFAULT_RELEASE_REPOSITORY)
+assert _DEFAULT_RELEASE_SOURCE is not None
+RELEASES_FEED_URL = _DEFAULT_RELEASE_SOURCE.feed_url
+RELEASES_PAGE_URL = _DEFAULT_RELEASE_SOURCE.page_url
+RELEASE_TAG_PATH = _DEFAULT_RELEASE_SOURCE.tag_path
+
+
 class AppVersionRead(BaseModel):
     current_version: str
     latest_version: str | None = None
     update_available: bool = False
-    release_url: str = RELEASES_PAGE_URL
+    release_url: str = ""
     release_name: str | None = None
     published_at: str | None = None
     check_enabled: bool = True
     check_succeeded: bool = True
+    release_repository: str | None = None
 
 
 _cached_result: tuple[float, AppVersionRead] | None = None
@@ -48,6 +81,7 @@ class ReleaseEntry:
 
 
 def _parse_version(value: str) -> Version | None:
+    """Parse StaffDeck's optional-v SemVer representation without build metadata."""
     normalized = value.strip()
     if normalized[:1].lower() == "v":
         normalized = normalized[1:]
@@ -59,6 +93,7 @@ def _parse_version(value: str) -> Version | None:
 
 
 def _is_newer(latest: str, current: str) -> bool:
+    """Return whether a valid latest version is strictly newer than the current version."""
     latest_version = _parse_version(latest)
     current_version = _parse_version(current)
     return bool(
@@ -68,7 +103,12 @@ def _is_newer(latest: str, current: str) -> bool:
     )
 
 
-def _release_tag(entry: ElementTree.Element, namespace: dict[str, str]) -> tuple[str, str]:
+def _release_tag(
+    entry: ElementTree.Element,
+    namespace: dict[str, str],
+    source: ReleaseSource,
+) -> tuple[str, str]:
+    """Extract a tag only when an alternate link belongs to the trusted release source."""
     link = entry.find("atom:link[@rel='alternate']", namespace)
     release_url = link.get("href", "").strip() if link is not None else ""
     if release_url:
@@ -77,20 +117,27 @@ def _release_tag(entry: ElementTree.Element, namespace: dict[str, str]) -> tuple
         if (
             parsed_url.scheme == "https"
             and parsed_url.netloc == "github.com"
-            and path.startswith(RELEASE_TAG_PATH)
+            and path.startswith(source.tag_path)
         ):
-            tag = path.removeprefix(RELEASE_TAG_PATH).strip("/")
+            tag = path.removeprefix(source.tag_path).strip("/")
             if _parse_version(tag) is not None:
                 return tag, release_url
+        return "", source.page_url
 
     entry_id = (entry.findtext("atom:id", default="", namespaces=namespace) or "").strip()
     tag = unquote(entry_id.rsplit("/", 1)[-1]) if "/" in entry_id else ""
     if _parse_version(tag) is not None:
-        return tag, RELEASES_PAGE_URL
-    return "", RELEASES_PAGE_URL
+        return tag, source.page_url
+    return "", source.page_url
 
 
-def _parse_release_feed(content: bytes, current: str) -> ReleaseEntry | None:
+def _parse_release_feed(
+    content: bytes,
+    current: str,
+    source: ReleaseSource | None = None,
+) -> ReleaseEntry | None:
+    """Select the newest compatible release from the trusted repository's Atom feed."""
+    selected_source = source or _DEFAULT_RELEASE_SOURCE
     root = ElementTree.fromstring(content)
     namespace = {"atom": "http://www.w3.org/2005/Atom"}
     current_version = _parse_version(current)
@@ -98,7 +145,7 @@ def _parse_release_feed(content: bytes, current: str) -> ReleaseEntry | None:
         return None
     releases: list[ReleaseEntry] = []
     for entry in root.findall("atom:entry", namespace):
-        tag, release_url = _release_tag(entry, namespace)
+        tag, release_url = _release_tag(entry, namespace, selected_source)
         parsed = _parse_version(tag)
         if parsed is None:
             continue
@@ -120,24 +167,33 @@ def _parse_release_feed(content: bytes, current: str) -> ReleaseEntry | None:
 
 
 def _fetch_version() -> AppVersionRead:
+    """Fetch one trusted feed when enabled, returning non-actionable failure states otherwise."""
     current = app_version()
+    source = _release_source(release_repository())
     if not update_check_enabled():
         return AppVersionRead(
             current_version=current,
             check_enabled=False,
             check_succeeded=False,
+            release_repository=source.repository if source is not None else None,
         )
+    if source is None:
+        return AppVersionRead(current_version=current, check_succeeded=False)
     try:
         response = httpx.get(
-            RELEASES_FEED_URL,
+            source.feed_url,
             headers={"Accept": "application/atom+xml", "User-Agent": "StaffDeck"},
             timeout=4.0,
             follow_redirects=True,
         )
         response.raise_for_status()
-        release = _parse_release_feed(response.content, current)
+        release = _parse_release_feed(response.content, current, source)
         if release is None:
-            return AppVersionRead(current_version=current, check_succeeded=False)
+            return AppVersionRead(
+                current_version=current,
+                check_succeeded=False,
+                release_repository=source.repository,
+            )
         return AppVersionRead(
             current_version=current,
             latest_version=release.version,
@@ -145,13 +201,19 @@ def _fetch_version() -> AppVersionRead:
             release_url=release.url,
             release_name=release.name,
             published_at=release.published_at,
+            release_repository=source.repository,
         )
     except (httpx.HTTPError, ElementTree.ParseError, ValueError, TypeError):
-        return AppVersionRead(current_version=current, check_succeeded=False)
+        return AppVersionRead(
+            current_version=current,
+            check_succeeded=False,
+            release_repository=source.repository,
+        )
 
 
 @router.get("/version", response_model=AppVersionRead)
 def get_app_version() -> AppVersionRead:
+    """Return a cached update result with shorter caching for unavailable release checks."""
     global _cached_result
     now = time.monotonic()
     with _cache_lock:

--- a/backend/app/distribution.py
+++ b/backend/app/distribution.py
@@ -1,0 +1,181 @@
+"""Resolve the immutable GitHub repository trusted by a packaged StaffDeck build."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+DEFAULT_RELEASE_REPOSITORY = "OpenBMB/StaffDeck"
+DISTRIBUTION_METADATA_FILENAME = "staffdeck-distribution.json"
+_OWNER_PATTERN = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?")
+_REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9._-]{0,98}[A-Za-z0-9_-])?")
+
+
+def validate_release_repository(value: str | None) -> str | None:
+    """Return a canonical owner/repository identity, or None for any URL-like or invalid input."""
+    if not isinstance(value, str) or value != value.strip() or value.count("/") != 1:
+        return None
+    owner, repository = value.split("/", 1)
+    if not _OWNER_PATTERN.fullmatch(owner) or not _REPOSITORY_PATTERN.fullmatch(repository):
+        return None
+    if repository in {".", ".."} or repository.endswith(".git") or ".." in repository:
+        return None
+    return value
+
+
+def _bundled_metadata_candidates() -> list[Path]:
+    """List packaged metadata locations in loader priority order without reading the filesystem."""
+    candidates: list[Path] = []
+    bundle_root = getattr(sys, "_MEIPASS", None)
+    if bundle_root:
+        candidates.append(Path(bundle_root) / DISTRIBUTION_METADATA_FILENAME)
+    if getattr(sys, "frozen", False):
+        executable = Path(sys.executable).resolve()
+        candidates.append(executable.parent / DISTRIBUTION_METADATA_FILENAME)
+        if sys.platform == "darwin" and len(executable.parents) >= 2:
+            candidates.append(executable.parents[1] / "Resources" / DISTRIBUTION_METADATA_FILENAME)
+    return candidates
+
+
+def _repository_from_metadata(payload: Any) -> str | None:
+    """Validate the exact bundled JSON object and return its sole repository identity."""
+    if not isinstance(payload, dict) or set(payload) != {"release_repository"}:
+        return None
+    return validate_release_repository(payload.get("release_repository"))
+
+
+def _bundled_release_repository() -> str | None:
+    """Read the first present metadata resource; malformed content fails closed without fallback."""
+    for candidate in _bundled_metadata_candidates():
+        try:
+            content = candidate.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            continue
+        except OSError:
+            return None
+        try:
+            payload = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        return _repository_from_metadata(payload)
+    return None
+
+
+def release_repository() -> str | None:
+    """Resolve runtime identity while preventing frozen apps from accepting mutable overrides."""
+    if getattr(sys, "frozen", False):
+        return _bundled_release_repository()
+    configured = os.environ.get("STAFFDECK_RELEASE_REPOSITORY")
+    if configured is None or configured == "":
+        return DEFAULT_RELEASE_REPOSITORY
+    return validate_release_repository(configured)
+
+
+def _repository_from_remote_url(remote_url: str) -> str | None:
+    """Convert supported GitHub HTTPS and SSH remotes into a canonical repository identity."""
+    if remote_url.startswith("git@github.com:"):
+        repository = remote_url.removeprefix("git@github.com:")
+    else:
+        parsed = urlsplit(remote_url)
+        try:
+            port = parsed.port
+        except ValueError:
+            return None
+        valid_https = (
+            parsed.scheme == "https"
+            and parsed.hostname == "github.com"
+            and parsed.username is None
+            and parsed.password is None
+            and port in {None, 443}
+        )
+        valid_ssh = (
+            parsed.scheme == "ssh"
+            and parsed.hostname == "github.com"
+            and parsed.username == "git"
+            and parsed.password is None
+            and port in {None, 22}
+        )
+        if not (valid_https or valid_ssh) or parsed.query or parsed.fragment:
+            return None
+        repository = parsed.path.lstrip("/")
+    repository = repository.removesuffix(".git")
+    return validate_release_repository(repository)
+
+
+def _origin_release_repository(repository_root: Path) -> str | None:
+    """Read the local origin with a bounded Git command and ignore missing or foreign remotes."""
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=repository_root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return _repository_from_remote_url(result.stdout.strip())
+
+
+def _configured_build_repository(variable_name: str) -> str | None:
+    """Validate one present build variable; malformed explicit input raises instead of falling back."""
+    configured = os.environ.get(variable_name)
+    if configured is None or configured == "":
+        return None
+    validated = validate_release_repository(configured)
+    if validated is None:
+        raise ValueError(f"{variable_name} must be a canonical owner/repository")
+    return validated
+
+
+def resolve_build_release_repository(repository_root: Path) -> str:
+    """Resolve package identity from explicit input, CI, GitHub origin, then the safe default."""
+    # A caller-supplied identity is authoritative for controlled local and test builds.
+    explicit = _configured_build_repository("STAFFDECK_RELEASE_REPOSITORY")
+    if explicit is not None:
+        return explicit
+
+    # GitHub Actions identifies the repository actually distributing the release artifact.
+    workflow_repository = _configured_build_repository("GITHUB_REPOSITORY")
+    if workflow_repository is not None:
+        return workflow_repository
+
+    # Local packaging follows a validated GitHub origin without trusting other hosting services.
+    origin_repository = _origin_release_repository(repository_root)
+    if origin_repository is not None:
+        return origin_repository
+
+    # Source archives without Git metadata preserve the historical upstream release default.
+    return DEFAULT_RELEASE_REPOSITORY
+
+
+def write_distribution_metadata(destination: Path, repository: str) -> Path:
+    """Validate and write immutable package metadata; invalid build input raises ValueError."""
+    validated = validate_release_repository(repository)
+    if validated is None:
+        raise ValueError(f"invalid StaffDeck release repository: {repository!r}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        json.dumps({"release_repository": validated}, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    return destination
+
+
+__all__ = [
+    "DEFAULT_RELEASE_REPOSITORY",
+    "DISTRIBUTION_METADATA_FILENAME",
+    "release_repository",
+    "resolve_build_release_repository",
+    "validate_release_repository",
+    "write_distribution_metadata",
+]

--- a/backend/tests/test_app_updates.py
+++ b/backend/tests/test_app_updates.py
@@ -9,12 +9,13 @@ from app import version
 from app.api import app_updates
 
 
-def _feed(*entries: tuple[str, str]) -> bytes:
+def _feed(*entries: tuple[str, str], repository: str = "OpenBMB/StaffDeck") -> bytes:
+    """Build a literal GitHub Atom feed for one repository and the supplied release entries."""
     body = "".join(
         (
             "<entry>"
             f"<updated>{published_at}</updated>"
-            f'<link rel="alternate" href="https://github.com/OpenBMB/StaffDeck/releases/tag/{tag}" />'
+            f'<link rel="alternate" href="https://github.com/{repository}/releases/tag/{tag}" />'
             f"<title>{tag}</title>"
             "</entry>"
         )
@@ -24,10 +25,11 @@ def _feed(*entries: tuple[str, str]) -> bytes:
 
 
 def _response(content: bytes) -> httpx.Response:
+    """Wrap feed bytes in the complete HTTP response shape consumed by the update checker."""
     return httpx.Response(
         200,
         content=content,
-        request=httpx.Request("GET", app_updates.RELEASES_FEED_URL),
+        request=httpx.Request("GET", "https://github.com/OpenBMB/StaffDeck/releases.atom"),
     )
 
 
@@ -86,8 +88,15 @@ def test_prerelease_build_can_advance_to_newer_prerelease_or_stable() -> None:
 
 
 def test_fetch_version_uses_validated_github_release_url(monkeypatch) -> None:
+    """Catch regressions that stop returning a validated configured-repository release link."""
     monkeypatch.setattr(app_updates, "app_version", lambda: "0.2.0")
     monkeypatch.setattr(app_updates, "update_check_enabled", lambda: True)
+    monkeypatch.setattr(
+        app_updates,
+        "release_repository",
+        lambda: "OpenBMB/StaffDeck",
+        raising=False,
+    )
     monkeypatch.setattr(
         app_updates.httpx,
         "get",
@@ -122,6 +131,7 @@ def test_source_deployment_skips_network_check_by_default(monkeypatch) -> None:
 
 
 def test_fetch_version_fails_silently_and_failure_is_cached(monkeypatch) -> None:
+    """Catch repeated network calls or surfaced errors after a cached feed failure."""
     calls = 0
 
     def fail(*args, **kwargs):
@@ -131,6 +141,12 @@ def test_fetch_version_fails_silently_and_failure_is_cached(monkeypatch) -> None
 
     monkeypatch.setattr(app_updates, "app_version", lambda: "0.2.0")
     monkeypatch.setattr(app_updates, "update_check_enabled", lambda: True)
+    monkeypatch.setattr(
+        app_updates,
+        "release_repository",
+        lambda: "OpenBMB/StaffDeck",
+        raising=False,
+    )
     monkeypatch.setattr(app_updates.httpx, "get", fail)
 
     first = app_updates.get_app_version()
@@ -143,6 +159,7 @@ def test_fetch_version_fails_silently_and_failure_is_cached(monkeypatch) -> None
 
 
 def test_release_tag_rejects_untrusted_alternate_link() -> None:
+    """Catch off-domain alternate links being salvaged into a trusted-looking release entry."""
     content = b"""<feed xmlns="http://www.w3.org/2005/Atom">
       <entry>
         <id>tag:github.com,2008:Repository/1/v0.2.1</id>
@@ -153,9 +170,89 @@ def test_release_tag_rejects_untrusted_alternate_link() -> None:
 
     release = app_updates._parse_release_feed(content, "0.2.0")
 
-    assert release is not None
-    assert release.version == "0.2.1"
-    assert release.url == app_updates.RELEASES_PAGE_URL
+    assert release is None
+
+
+def test_fetch_version_uses_packaged_repository_for_feed_and_release_url(monkeypatch) -> None:
+    """Catch a Fork package querying or linking to the upstream release repository."""
+    requested_urls: list[str] = []
+
+    def fetch(url: str, **kwargs) -> httpx.Response:
+        """Record the real boundary argument while returning a complete matching feed response."""
+        requested_urls.append(url)
+        return httpx.Response(
+            200,
+            content=_feed(
+                ("v0.2.1", "2026-08-05T12:00:00Z"),
+                repository="JnyRoad/StaffDeck",
+            ),
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(app_updates, "app_version", lambda: "0.2.0")
+    monkeypatch.setattr(app_updates, "update_check_enabled", lambda: True)
+    monkeypatch.setattr(
+        app_updates,
+        "release_repository",
+        lambda: "JnyRoad/StaffDeck",
+        raising=False,
+    )
+    monkeypatch.setattr(app_updates.httpx, "get", fetch)
+
+    result = app_updates._fetch_version()
+
+    assert requested_urls == ["https://github.com/JnyRoad/StaffDeck/releases.atom"]
+    assert result.release_repository == "JnyRoad/StaffDeck"
+    assert result.release_url == "https://github.com/JnyRoad/StaffDeck/releases/tag/v0.2.1"
+    assert result.update_available is True
+    assert result.check_succeeded is True
+
+
+def test_fetch_version_rejects_release_entry_from_other_repository(monkeypatch) -> None:
+    """Catch a valid GitHub tag from another repository becoming an actionable update."""
+    monkeypatch.setattr(app_updates, "app_version", lambda: "0.2.0")
+    monkeypatch.setattr(app_updates, "update_check_enabled", lambda: True)
+    monkeypatch.setattr(
+        app_updates,
+        "release_repository",
+        lambda: "JnyRoad/StaffDeck",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        app_updates.httpx,
+        "get",
+        lambda url, **kwargs: httpx.Response(
+            200,
+            content=_feed(("v9.9.9", "2026-08-05T12:00:00Z")),
+            request=httpx.Request("GET", url),
+        ),
+    )
+
+    result = app_updates._fetch_version()
+
+    assert result.release_repository == "JnyRoad/StaffDeck"
+    assert result.release_url == ""
+    assert result.update_available is False
+    assert result.check_succeeded is False
+
+
+def test_fetch_version_skips_network_when_distribution_identity_is_invalid(monkeypatch) -> None:
+    """Catch a frozen package without trusted metadata falling back to any network release feed."""
+    monkeypatch.setattr(app_updates, "app_version", lambda: "0.2.0")
+    monkeypatch.setattr(app_updates, "update_check_enabled", lambda: True)
+    monkeypatch.setattr(app_updates, "release_repository", lambda: None, raising=False)
+    monkeypatch.setattr(
+        app_updates.httpx,
+        "get",
+        lambda *args, **kwargs: pytest.fail("invalid identity must not access GitHub"),
+    )
+
+    result = app_updates._fetch_version()
+
+    assert result.release_repository is None
+    assert result.release_url == ""
+    assert result.update_available is False
+    assert result.check_succeeded is False
 
 
 def test_app_version_priority_and_macos_resources(monkeypatch, tmp_path: Path) -> None:

--- a/backend/tests/test_distribution.py
+++ b/backend/tests/test_distribution.py
@@ -1,0 +1,251 @@
+"""Verify the trusted repository identity embedded in StaffDeck packages."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _distribution_module() -> ModuleType:
+    """Load the production boundary and turn a missing module into explicit RED evidence."""
+    try:
+        return importlib.import_module("app.distribution")
+    except ModuleNotFoundError:
+        pytest.fail("app.distribution is not implemented yet")
+
+
+def _git(repository: Path, *arguments: str) -> None:
+    """Create controlled local Git state for origin-resolution tests without network access."""
+    subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+
+@pytest.mark.parametrize(
+    "repository",
+    ["OpenBMB/StaffDeck", "JnyRoad/StaffDeck", "owner-1/repo_name", "a/repo.with-dots"],
+)
+def test_validate_release_repository_accepts_canonical_identity(repository: str) -> None:
+    """Catch rejection or rewriting of valid GitHub owner/repository identities."""
+    distribution = _distribution_module()
+
+    assert distribution.validate_release_repository(repository) == repository
+
+
+@pytest.mark.parametrize(
+    "repository",
+    [
+        None,
+        "",
+        " OpenBMB/StaffDeck",
+        "OpenBMB/StaffDeck ",
+        "OpenBMB",
+        "OpenBMB/StaffDeck/extra",
+        "-OpenBMB/StaffDeck",
+        "OpenBMB-/StaffDeck",
+        "OpenBMB/.",
+        "OpenBMB/..",
+        "OpenBMB/StaffDeck.git",
+        "OpenBMB/staff deck",
+        "https://github.com/OpenBMB/StaffDeck",
+        "git@github.com:OpenBMB/StaffDeck.git",
+        "OpenBMB/StaffDeck?tab=releases",
+        "OpenBMB/StaffDeck#latest",
+    ],
+)
+def test_validate_release_repository_rejects_noncanonical_identity(
+    repository: str | None,
+) -> None:
+    """Catch acceptance of URL syntax, traversal segments, or malformed repository names."""
+    distribution = _distribution_module()
+
+    assert distribution.validate_release_repository(repository) is None
+
+
+def test_frozen_release_repository_uses_bundled_metadata_and_ignores_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Catch runtime environment overrides changing an installed package's trusted distributor."""
+    distribution = _distribution_module()
+    metadata = tmp_path / "staffdeck-distribution.json"
+    metadata.write_text(
+        json.dumps({"release_repository": "JnyRoad/StaffDeck"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(distribution.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(distribution.sys, "_MEIPASS", str(tmp_path), raising=False)
+    monkeypatch.setenv("STAFFDECK_RELEASE_REPOSITORY", "SomeoneElse/StaffDeck")
+
+    assert distribution.release_repository() == "JnyRoad/StaffDeck"
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["", "not-json", "{}", '{"release_repository":"https://github.com/OpenBMB/StaffDeck"}'],
+)
+def test_frozen_release_repository_fails_closed_for_invalid_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    content: str,
+) -> None:
+    """Catch malformed package metadata silently falling back to an unrelated repository."""
+    distribution = _distribution_module()
+    (tmp_path / "staffdeck-distribution.json").write_text(content, encoding="utf-8")
+    monkeypatch.setattr(distribution.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(distribution.sys, "_MEIPASS", str(tmp_path), raising=False)
+    monkeypatch.setenv("STAFFDECK_RELEASE_REPOSITORY", "SomeoneElse/StaffDeck")
+
+    assert distribution.release_repository() is None
+
+
+def test_frozen_release_repository_fails_closed_when_metadata_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Catch a missing bundled identity being replaced by a runtime environment value."""
+    distribution = _distribution_module()
+    monkeypatch.setattr(distribution.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(distribution.sys, "_MEIPASS", str(tmp_path), raising=False)
+    monkeypatch.setenv("STAFFDECK_RELEASE_REPOSITORY", "SomeoneElse/StaffDeck")
+
+    assert distribution.release_repository() is None
+
+
+def test_write_distribution_metadata_emits_exact_valid_payload(tmp_path: Path) -> None:
+    """Catch packaging metadata that is invalid, incomplete, or written to the wrong path."""
+    distribution = _distribution_module()
+    destination = tmp_path / "build" / "staffdeck-distribution.json"
+
+    written_path = distribution.write_distribution_metadata(
+        destination,
+        "JnyRoad/StaffDeck",
+    )
+
+    assert written_path == destination
+    assert json.loads(destination.read_text(encoding="utf-8")) == {
+        "release_repository": "JnyRoad/StaffDeck"
+    }
+
+
+def test_build_repository_prefers_explicit_identity_over_github_actions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Catch an explicit local build identity being ignored in favor of ambient CI state."""
+    distribution = _distribution_module()
+    monkeypatch.setenv("STAFFDECK_RELEASE_REPOSITORY", "JnyRoad/StaffDeck")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "OpenBMB/StaffDeck")
+
+    assert distribution.resolve_build_release_repository(tmp_path) == "JnyRoad/StaffDeck"
+
+
+def test_build_repository_uses_github_actions_repository(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Catch release workflows failing to bind packages to the repository running the build."""
+    distribution = _distribution_module()
+    monkeypatch.delenv("STAFFDECK_RELEASE_REPOSITORY", raising=False)
+    monkeypatch.setenv("GITHUB_REPOSITORY", "JnyRoad/StaffDeck")
+
+    assert distribution.resolve_build_release_repository(tmp_path) == "JnyRoad/StaffDeck"
+
+
+@pytest.mark.parametrize(
+    "remote_url",
+    [
+        "https://github.com/JnyRoad/StaffDeck.git",
+        "git@github.com:JnyRoad/StaffDeck.git",
+        "ssh://git@github.com/JnyRoad/StaffDeck.git",
+    ],
+)
+def test_build_repository_derives_valid_github_origin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    remote_url: str,
+) -> None:
+    """Catch supported GitHub remote forms resolving to different package identities."""
+    distribution = _distribution_module()
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "remote", "add", "origin", remote_url)
+    monkeypatch.delenv("STAFFDECK_RELEASE_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    assert distribution.resolve_build_release_repository(tmp_path) == "JnyRoad/StaffDeck"
+
+
+@pytest.mark.parametrize("remote_url", [None, "https://gitlab.com/JnyRoad/StaffDeck.git"])
+def test_build_repository_uses_safe_default_without_github_origin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    remote_url: str | None,
+) -> None:
+    """Catch source archives or foreign remotes producing an undefined update identity."""
+    distribution = _distribution_module()
+    _git(tmp_path, "init", "-q")
+    if remote_url is not None:
+        _git(tmp_path, "remote", "add", "origin", remote_url)
+    monkeypatch.delenv("STAFFDECK_RELEASE_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    assert distribution.resolve_build_release_repository(tmp_path) == "OpenBMB/StaffDeck"
+
+
+def test_build_repository_rejects_invalid_explicit_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Catch malformed explicit build input silently falling through to another distributor."""
+    distribution = _distribution_module()
+    monkeypatch.setenv(
+        "STAFFDECK_RELEASE_REPOSITORY",
+        "https://github.com/JnyRoad/StaffDeck",
+    )
+    monkeypatch.setenv("GITHUB_REPOSITORY", "OpenBMB/StaffDeck")
+
+    with pytest.raises(ValueError, match="STAFFDECK_RELEASE_REPOSITORY"):
+        distribution.resolve_build_release_repository(tmp_path)
+
+
+def test_source_release_repository_uses_valid_development_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catch non-frozen test and development processes ignoring an explicit valid identity."""
+    distribution = _distribution_module()
+    monkeypatch.setattr(distribution.sys, "frozen", False, raising=False)
+    monkeypatch.setenv("STAFFDECK_RELEASE_REPOSITORY", "JnyRoad/StaffDeck")
+
+    assert distribution.release_repository() == "JnyRoad/StaffDeck"
+
+
+def test_source_release_repository_defaults_to_upstream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catch source update opt-in losing its existing upstream repository default."""
+    distribution = _distribution_module()
+    monkeypatch.setattr(distribution.sys, "frozen", False, raising=False)
+    monkeypatch.delenv("STAFFDECK_RELEASE_REPOSITORY", raising=False)
+
+    assert distribution.release_repository() == "OpenBMB/StaffDeck"
+
+
+def test_source_release_repository_rejects_invalid_development_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catch malformed source overrides silently falling back to an unrelated repository."""
+    distribution = _distribution_module()
+    monkeypatch.setattr(distribution.sys, "frozen", False, raising=False)
+    monkeypatch.setenv("STAFFDECK_RELEASE_REPOSITORY", "OpenBMB/StaffDeck/extra")
+
+    assert distribution.release_repository() is None

--- a/backend/tests/test_packaging_deps.py
+++ b/backend/tests/test_packaging_deps.py
@@ -1,5 +1,9 @@
+"""Verify release packages keep their required runtime and build-time contracts."""
+
 import importlib
 from pathlib import Path
+
+import yaml
 
 # 渠道(微信/企微)打包必需依赖:PyInstaller hiddenimports 防回归删漏
 REQUIRED_MODULES = ("aibot", "websockets", "aiohttp", "pyee", "dotenv", "cryptography")
@@ -58,3 +62,22 @@ def test_windows_release_supports_external_signer_and_fails_closed() -> None:
     assert '$signature.Status -ne "Valid"' in signer
     for extension in ('".exe"', '".dll"', '".pyd"', '".node"'):
         assert extension in build
+
+
+def test_pyinstaller_bundle_contains_distribution_metadata_resource() -> None:
+    """Catch packaged applications omitting their immutable release repository identity."""
+    spec_path = Path(__file__).resolve().parents[2] / "packaging" / "ultrarag.spec"
+    content = spec_path.read_text(encoding="utf-8")
+
+    assert "staffdeck-distribution.json" in content
+    assert "DISTRIBUTION_METADATA_FILE" in content
+    assert '(str(DISTRIBUTION_METADATA_FILE), ".")' in content
+
+
+def test_release_workflow_binds_distribution_to_running_repository() -> None:
+    """Catch release jobs building packages that trust a hard-coded distributor."""
+    workflow_path = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+    workflow = yaml.load(workflow_path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    build_step = next(step for step in workflow["jobs"]["build"]["steps"] if step.get("name") == "Build")
+
+    assert build_step["env"]["STAFFDECK_RELEASE_REPOSITORY"] == "${{ github.repository }}"

--- a/backend/tests/test_packaging_deps.py
+++ b/backend/tests/test_packaging_deps.py
@@ -1,6 +1,10 @@
 """Verify release packages keep their required runtime and build-time contracts."""
 
 import importlib
+import shutil
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 
 import yaml
@@ -81,3 +85,73 @@ def test_release_workflow_binds_distribution_to_running_repository() -> None:
     build_step = next(step for step in workflow["jobs"]["build"]["steps"] if step.get("name") == "Build")
 
     assert build_step["env"]["STAFFDECK_RELEASE_REPOSITORY"] == "${{ github.repository }}"
+
+
+def test_pyinstaller_spec_imports_backend_modules_before_analysis(tmp_path: Path) -> None:
+    """Run the real spec in isolation; writes stay in tmp_path and import failures fail the test."""
+    source_root = Path(__file__).resolve().parents[2]
+    isolated_root = tmp_path / "checkout"
+    isolated_backend = isolated_root / "backend"
+    isolated_packaging = isolated_root / "packaging"
+    isolated_app = isolated_backend / "app"
+
+    isolated_app.mkdir(parents=True)
+    isolated_packaging.mkdir(parents=True)
+    (isolated_root / "frontend-enterprise" / "dist").mkdir(parents=True)
+    shutil.copy2(source_root / "packaging" / "ultrarag.spec", isolated_packaging / "ultrarag.spec")
+    shutil.copy2(source_root / "backend" / "app" / "distribution.py", isolated_app / "distribution.py")
+    (isolated_app / "__init__.py").write_text("", encoding="utf-8")
+    (isolated_backend / "VERSION").write_text("0.0.0-test\n", encoding="utf-8")
+
+    spec_runner = textwrap.dedent(
+        """
+        import runpy
+        import sys
+        import types
+
+        pyinstaller = types.ModuleType("PyInstaller")
+        pyinstaller.__path__ = []
+        utils = types.ModuleType("PyInstaller.utils")
+        utils.__path__ = []
+        hooks = types.ModuleType("PyInstaller.utils.hooks")
+        hooks.collect_data_files = lambda *args, **kwargs: []
+        hooks.collect_submodules = lambda *args, **kwargs: []
+        hooks.copy_metadata = lambda *args, **kwargs: []
+        sys.modules.update(
+            {
+                "PyInstaller": pyinstaller,
+                "PyInstaller.utils": utils,
+                "PyInstaller.utils.hooks": hooks,
+            }
+        )
+
+        def analysis(*args, **kwargs):
+            'Return the minimal Analysis shape consumed by the spec.'
+            return types.SimpleNamespace(pure=[], scripts=[], binaries=[], datas=[])
+
+        def build_target(*args, **kwargs):
+            'Stand in for build targets without producing filesystem artifacts.'
+            return types.SimpleNamespace()
+
+        runpy.run_path(
+            sys.argv[1],
+            init_globals={
+                "Analysis": analysis,
+                "PYZ": build_target,
+                "EXE": build_target,
+                "COLLECT": build_target,
+                "BUNDLE": build_target,
+            },
+        )
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-I", "-c", spec_runner, str(isolated_packaging / "ultrarag.spec")],
+        cwd=isolated_backend,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/packaging/ultrarag.spec
+++ b/packaging/ultrarag.spec
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, copy_metadata
 
+from app.distribution import resolve_build_release_repository, write_distribution_metadata
+
 BACKEND = Path.cwd()                      # 约定在 backend/ 下执行
 REPO = BACKEND.parent
 DIST = REPO / "frontend-enterprise" / "dist"
@@ -26,6 +28,12 @@ VERSION_FILE = REPO / "packaging" / "build" / "staffdeck-version.txt"
 VERSION_FILE.parent.mkdir(parents=True, exist_ok=True)
 VERSION_FILE.write_text(BUNDLE_VERSION + "\n", encoding="utf-8")
 
+DISTRIBUTION_REPOSITORY = resolve_build_release_repository(REPO)
+DISTRIBUTION_METADATA_FILE = (
+    REPO / "packaging" / "build" / "staffdeck-distribution.json"
+)
+write_distribution_metadata(DISTRIBUTION_METADATA_FILE, DISTRIBUTION_REPOSITORY)
+
 # 平台图标：macOS 用 .icns，Windows 用 .ico，Linux(EXE) 不用
 _exe_icon = None
 if sys.platform == "win32" and ICO.exists():
@@ -34,6 +42,7 @@ if sys.platform == "win32" and ICO.exists():
 datas = [
     (str(DIST), "frontend-enterprise/dist"),
     (str(VERSION_FILE), "."),
+    (str(DISTRIBUTION_METADATA_FILE), "."),
     (str(ASSETS / "staffdeck.png"), "packaging/assets"),
     (str(BACKEND / "app" / "llm" / "prompts"), "app/llm/prompts"),
     (str(BACKEND / "app" / "db" / "seed_fixtures"), "app/db/seed_fixtures"),

--- a/packaging/ultrarag.spec
+++ b/packaging/ultrarag.spec
@@ -6,9 +6,11 @@ import sys
 from pathlib import Path
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, copy_metadata
 
-from app.distribution import resolve_build_release_repository, write_distribution_metadata
-
 BACKEND = Path.cwd()                      # 约定在 backend/ 下执行
+sys.path.insert(0, str(BACKEND))
+
+from app.distribution import resolve_build_release_repository, write_distribution_metadata  # noqa: E402
+
 REPO = BACKEND.parent
 DIST = REPO / "frontend-enterprise" / "dist"
 ASSETS = REPO / "packaging" / "assets"


### PR DESCRIPTION
## Summary
Make StaffDeck release discovery distributor-aware so the same source works for OpenBMB builds and downstream forks without repository-specific code edits.

## Changes
- Add validated build-time distribution metadata and immutable frozen-runtime lookup.
- Derive trusted GitHub release feed, page, and tag URLs from the packaged repository identity.
- Bind GitHub Actions packages to `${{ github.repository }}`.
- Preserve source-mode opt-in and stable/prerelease comparison behavior while failing closed on invalid metadata or off-repository links.

## Testing
- Focused distribution, update, and packaging tests on `upstream/main`: 63 passed.
- Ruff checks on changed Python files: passed.
- The generic patch has the same stable patch ID as the fork implementation.

## Risks
- A full PyInstaller/DMG packaging build was not run.
- Invalid or missing frozen metadata disables update discovery by design.