### PR TITLE
[codex] 修复子 SOP 工具授权与依赖刷新

### DIFF
--- a/backend/app/core/capability_manifest.py
+++ b/backend/app/core/capability_manifest.py
@@ -17,6 +17,7 @@ from app.capabilities.local_general_skill import package_from_row
 from app.core.task_request_compiler import (
     CapabilityDescriptor,
     CapabilityManifest,
+    current_step_authorization_skill_ids,
     current_step_capability_refs,
 )
 from app.db.models import (
@@ -64,6 +65,7 @@ class CapabilityManifestBuilder:
         if agent_id and get_agent(self.db, tenant_id, agent_id) is None:
             raise CapabilityAuthorizationError("当前员工不存在、已归档或不属于该租户。")
         refs = current_step_capability_refs(skill, step_id)
+        authorization_skill_ids = current_step_authorization_skill_ids(skill, step_id)
         available: list[CapabilityDescriptor] = []
         unavailable: list[CapabilityDescriptor] = []
 
@@ -187,8 +189,8 @@ class CapabilityManifestBuilder:
             explicitly_allowed = any(tool_by_ref.get(ref) is row for ref in refs["tool_ids"])
             if scope == "sop_specific" and not explicitly_allowed:
                 continue
-            if row.allowed_skills_json and (
-                skill is None or skill.skill_id not in row.allowed_skills_json
+            if row.allowed_skills_json and not authorization_skill_ids.intersection(
+                str(value).strip() for value in row.allowed_skills_json if str(value).strip()
             ):
                 if explicitly_allowed:
                     unavailable.append(

--- a/backend/app/core/task_request_compiler.py
+++ b/backend/app/core/task_request_compiler.py
@@ -215,6 +215,33 @@ def current_step_capability_refs(skill: Skill | None, step_id: str | None) -> di
     return result
 
 
+def current_step_authorization_skill_ids(
+    skill: Skill | None,
+    step_id: str | None,
+) -> set[str]:
+    """Return every SOP identity that authorizes the current expanded node.
+
+    Nested SOP nodes execute inside the parent's persisted task frame, so the
+    runtime ``Skill`` keeps the parent ``skill_id``.  The expansion metadata is
+    the authoritative source for the child call path.  Keeping both identities
+    preserves parent-level tool grants while allowing a child-only grant to
+    remain valid after expansion.
+    """
+    if skill is None:
+        return set()
+    authorized = {str(skill.skill_id or "").strip()}
+    node = _current_node(skill, step_id)
+    metadata = (node or {}).get("metadata")
+    if isinstance(metadata, dict):
+        nested_path = metadata.get("nested_sop_path")
+        if isinstance(nested_path, list):
+            authorized.update(_text_list(nested_path))
+        source_sop_id = str(metadata.get("source_sop_id") or "").strip()
+        if source_sop_id:
+            authorized.add(source_sop_id)
+    return {value for value in authorized if value}
+
+
 def _current_node(skill: Skill | None, step_id: str | None) -> dict[str, Any] | None:
     if skill is None:
         return None

--- a/backend/tests/test_dev_scripts.py
+++ b/backend/tests/test_dev_scripts.py
@@ -120,6 +120,49 @@ def test_dev_cli_refreshes_incomplete_frontend_dependencies(monkeypatch) -> None
     assert calls[1][-3:] == ["ci", "--no-audit", "--no-fund"]
 
 
+def test_dev_cli_detects_missing_backend_dependency(tmp_path, monkeypatch) -> None:
+    dev = _load_script("dev")
+    backend = tmp_path / "backend"
+    backend.mkdir()
+    (backend / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["present>=1", "missing>=1"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(dev, "ROOT_DIR", tmp_path)
+    monkeypatch.setattr(
+        dev,
+        "_installed_distribution_version",
+        lambda name: "1.2" if name == "present" else None,
+    )
+
+    assert dev._backend_dependencies_complete() is False
+
+
+def test_dev_cli_refreshes_incomplete_backend_dependencies(monkeypatch) -> None:
+    dev = _load_script("dev")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(dev, "_backend_dependencies_complete", lambda: False)
+
+    def run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(dev.subprocess, "run", run)
+
+    dev._ensure_backend_dependencies()
+
+    assert calls == [
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-e",
+            str(ROOT_DIR / "backend"),
+        ]
+    ]
+
+
 def test_supervisor_does_not_restart_during_startup_grace(monkeypatch) -> None:
     supervisor = _load_script("dev_supervisor")
 

--- a/backend/tests/test_harness_v2.py
+++ b/backend/tests/test_harness_v2.py
@@ -102,6 +102,7 @@ from app.session.session_schema import (
     TurnPlan,
 )
 from app.session.attachment_store import stage_chat_attachment
+from app.skills.nesting import expand_sop_for_execution
 from app.skills.skill_schema import SkillCapabilityRefs
 from app.tools.tool_schema import ToolResult
 
@@ -1353,6 +1354,85 @@ def test_capability_manifest_only_exposes_current_step_sop_specific_resources() 
     assert shared_descriptor.input_schema["required"] == ["query", "operation"]
     assert shared_descriptor.metadata["execution_policy"] == "instructions_only"
     assert shared_descriptor.metadata["script_execution"] == "use_harness_tools"
+
+
+def test_nested_sop_tool_grant_survives_parent_expansion() -> None:
+    engine = _test_engine()
+    with Session(engine) as db:
+        db.add(Tenant(id="tenant-demo", name="Demo"))
+        db.add(
+            AgentProfile(
+                id="agent-overall",
+                tenant_id="tenant-demo",
+                name="整体智能体",
+                is_overall=True,
+            )
+        )
+        tool = Tool(
+            id="tool-child",
+            tenant_id="tenant-demo",
+            name="child.lookup",
+            method="POST",
+            url="https://example.test/lookup",
+            capability_scope="sop_specific",
+            allowed_skills_json=["child"],
+        )
+        db.add(tool)
+        db.flush()
+        ensure_open_gallery_binding(db, "tenant-demo", "tool", tool.id)
+        db.commit()
+
+        child = Skill(
+            id="skill-child",
+            tenant_id="tenant-demo",
+            skill_id="child",
+            name="子流程",
+            status="published",
+            content_json={
+                "capability_scope": "sop_specific",
+                "start_node_id": "lookup",
+                "terminal_node_ids": ["lookup"],
+                "nodes": [
+                    {
+                        "node_id": "lookup",
+                        "type": "tool_call",
+                        "name": "查询",
+                        "capability_refs": {"tool_ids": [tool.id]},
+                    }
+                ],
+                "edges": [],
+            },
+        )
+        parent = Skill(
+            id="skill-parent",
+            tenant_id="tenant-demo",
+            skill_id="parent",
+            name="父流程",
+            status="published",
+            content_json={
+                "capability_scope": "general",
+                "start_node_id": "nested",
+                "terminal_node_ids": ["nested"],
+                "nodes": [
+                    {
+                        "node_id": "nested",
+                        "type": "subflow",
+                        "name": "调用子流程",
+                        "sub_sop_id": "child",
+                    }
+                ],
+                "edges": [],
+            },
+        )
+        expanded = expand_sop_for_execution(parent, [parent, child])
+        manifest = CapabilityManifestBuilder(db).build(
+            "tenant-demo",
+            "agent-overall",
+            expanded,
+            "nested::child::lookup",
+        )
+
+    assert "child.lookup" in manifest.allowed_names()
 
 
 def test_general_tools_remain_discoverable_across_sop_steps() -> None:

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -227,6 +227,64 @@ def _ensure_frontend_dependencies() -> None:
     )
 
 
+def _installed_distribution_version(name: str) -> str | None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version(name)
+    except PackageNotFoundError:
+        return None
+
+
+def _backend_dependencies_complete() -> bool:
+    """Check current pyproject runtime requirements against the active venv."""
+    try:
+        import tomllib
+
+        from packaging.requirements import Requirement
+
+        document = tomllib.loads(
+            (ROOT_DIR / "backend" / "pyproject.toml").read_text(encoding="utf-8")
+        )
+        requirements = document.get("project", {}).get("dependencies", [])
+    except (ImportError, OSError, ValueError):
+        return False
+    if not isinstance(requirements, list):
+        return False
+    for raw in requirements:
+        try:
+            requirement = Requirement(str(raw))
+        except ValueError:
+            return False
+        if requirement.marker and not requirement.marker.evaluate():
+            continue
+        installed = _installed_distribution_version(requirement.name)
+        if installed is None or (
+            requirement.specifier and not requirement.specifier.contains(installed)
+        ):
+            return False
+    return True
+
+
+def _ensure_backend_dependencies() -> None:
+    """Refresh the editable backend install after a pull changes dependencies."""
+    if _backend_dependencies_complete():
+        return
+    print("Backend dependencies changed or are incomplete; refreshing the active environment...")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-e",
+            str(ROOT_DIR / "backend"),
+        ],
+        cwd=ROOT_DIR,
+        check=True,
+    )
+
+
 def _ensure_sandbox_runtime() -> None:
     runtime = ROOT_DIR / "packaging" / "sandbox_runtime"
     cli = runtime / "node_modules" / "@anthropic-ai" / "sandbox-runtime" / "dist" / "cli.js"
@@ -319,6 +377,7 @@ def _start_detached(supervisor) -> int:
 def command_up(detach_flag: bool) -> int:
     detach = detach_flag or _env_flag("DETACH")
     os.environ.setdefault("AUTO_RESTART", "1" if detach else "0")
+    _ensure_backend_dependencies()
     supervisor = _load_supervisor()
     _ensure_frontend_dependencies()
     supervisor.validate_prerequisites()


### PR DESCRIPTION
## 变更

- 子 SOP 展开后，工具 `allowed_skills` 授权同时识别父 SOP 与展开节点的真实 `source_sop_id` / 嵌套调用路径。
- 仍要求工具出现在当前节点的 `capability_refs` 中，避免把子 SOP 专属工具扩散到父流程其他节点。
- `dev_up` 启动前读取 `backend/pyproject.toml`，检查当前虚拟环境是否满足运行时依赖；依赖缺失或版本不匹配时自动刷新 editable 安装。
- 增加子 SOP 专属工具和后端依赖漂移的回归测试。

## 根因

子 SOP 节点运行时会展开到父 SOP 的 TaskFrame 中，但能力清单此前只用父 SOP 的 `skill_id` 校验工具 `allowed_skills`，导致只授权给子 SOP 的工具被误判为未授权。另一方面，拉取新增 Python 依赖后，`dev_up` 只会检查前端依赖，不会刷新已有后端虚拟环境，应用会在导入新增模块时持续退出。

## 验证

- `ruff check`：通过。
- `pytest backend/tests/test_sop_nesting.py backend/tests/test_dev_scripts.py backend/tests/test_harness_v2.py -q`：114 passed。
- 真实执行 `scripts/dev_up.sh --detach`：成功；`/api/health` 返回 200，单 supervisor / 单 app。
- 全量后端：2036 passed；当前 main 仍存在与本 PR 无关的存量迁移/运行时测试失败。代表性 `test_channel_scope_rebuild_migration` 已在未修改的 `origin/main@3704a258` 临时克隆中单独复现。
