### PR TITLE
fix(teams): clamp bid award scores to 0-10

### DIFF
--- a/backend/app/teams/service.py
+++ b/backend/app/teams/service.py
@@ -266,8 +266,9 @@ def parse_bid_award(reply: str, candidate_ids: set[str]) -> dict[str, Any] | Non
                     score = float(item.get("score"))
                 except (TypeError, ValueError):
                     continue
+                # 与 parse_bid_scores 一致:裁决分数同样落在 0-10,避免污染血条与看板
                 scores[str(agent_id)] = {
-                    "score": score,
+                    "score": min(10.0, max(0.0, score)),
                     "rationale": str(item.get("rationale") or "").strip(),
                 }
         return {

--- a/backend/tests/test_teams_bidding.py
+++ b/backend/tests/test_teams_bidding.py
@@ -171,6 +171,23 @@ def test_parse_bid_award_requires_candidate_winner() -> None:
     assert parse_bid_award("没有块", candidates) is None
 
 
+def test_parse_bid_award_clamps_scores_to_zero_ten() -> None:
+    candidates = {"agent_a", "agent_b"}
+    reply = (
+        "```json\n"
+        '{"bid_award": {"winner_agent_id": "agent_a", '
+        '"scores": {"agent_a": {"score": 12.0, "rationale": "超出"}, '
+        '"agent_b": {"score": -3.0, "rationale": "负分"}}, '
+        '"comment": "甲更匹配"}}\n```'
+    )
+    award = parse_bid_award(reply, candidates)
+    assert award is not None
+    assert award["winner_agent_id"] == "agent_a"
+    # 与 parse_bid_scores 一致,裁决分数也截断到 0-10,避免污染血条(HP)与看板
+    assert award["scores"]["agent_a"] == {"score": 10.0, "rationale": "超出"}
+    assert award["scores"]["agent_b"] == {"score": 0.0, "rationale": "负分"}
+
+
 def test_parse_bid_scores() -> None:
     candidates = {"agent_a", "agent_b"}
     scores = parse_bid_scores(_score_reply(("agent_a", 9.0), ("agent_b", 8.0)), candidates)


### PR DESCRIPTION
## Summary

`parse_bid_award` wrote TL verdict scores straight to `bid.score` without the 0–10 clamp that `parse_bid_scores` applies. An out-of-range verdict score (e.g. `12.0` or `-3.0`) therefore flowed into the persisted bid record and into `candidate_hp`, which computes HP loss as `10 - score` (see `service.py:746`) — an over-10 score could push an already-eliminated candidate's HP back above zero.

## Why

The same `bid.score` field is written from two parsing paths:

- `parse_bid_scores` clamps: `score: min(10.0, max(0.0, score))` (line 239)
- `parse_bid_award` does **not** clamp (line 269)

Only the clamp-on-scores path is exercised in normal flow; the award path still fills in any bid that missed a round score, so the inconsistency is reachable. The fix aligns both paths so the score's 0–10 domain holds everywhere.

## Changes

- `backend/app/teams/service.py`: clamp `parse_bid_award` scores to `[0, 10]`, matching `parse_bid_scores`.
- `backend/tests/test_teams_bidding.py`: new regression test asserting `12.0` clamps to `10.0` and `-3.0` clamps to `0.0`.

## Testing

- `pytest backend/tests/test_teams_bidding.py` — 23 passed (includes the new test).
- `pytest backend/tests/test_teams_api.py tests/test_teams_conversations.py tests/test_teams_ops.py tests/test_teams_bidding.py` — 90 passed.
- `ruff check backend/app/teams/service.py` — clean.
- Sabotage check: removing the clamp makes the new test fail; restoring it makes it pass.

Related: #229 (its Q3 asks about the recommended way for a delivery manager to see member-task status; this fixes one defect in that area — an in-range score contract for team bidding).